### PR TITLE
[#29] [Chore] Create the MyCoin module as a local Swift package

### DIFF
--- a/CryptoPrices.xcodeproj/project.pbxproj
+++ b/CryptoPrices.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		249752BD2941901E003C6238 /* MyCoin in Frameworks */ = {isa = PBXBuildFile; productRef = 249752BC2941901E003C6238 /* MyCoin */; };
 		4D0A1DA029349D660038624D /* CryptoPricesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D0A1D9F29349D660038624D /* CryptoPricesApp.swift */; };
 		4D0A1DA229349D660038624D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D0A1DA129349D660038624D /* ContentView.swift */; };
 		4D0A1DA429349D670038624D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4D0A1DA329349D670038624D /* Assets.xcassets */; };
@@ -35,6 +36,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		249752BB29418C64003C6238 /* MyCoin */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = MyCoin; path = CryptoPrices/Sources/MyCoin; sourceTree = "<group>"; };
 		4D0A1D9C29349D660038624D /* CryptoPrices.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CryptoPrices.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4D0A1D9F29349D660038624D /* CryptoPricesApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoPricesApp.swift; sourceTree = "<group>"; };
 		4D0A1DA129349D660038624D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -55,6 +57,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4DF0741C293C8D3900E1274D /* Home in Frameworks */,
+				249752BD2941901E003C6238 /* MyCoin in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -87,6 +90,7 @@
 			children = (
 				4DF0741D293C90F100E1274D /* Styleguide */,
 				4DF07418293C8AA200E1274D /* Home */,
+				249752BB29418C64003C6238 /* MyCoin */,
 				4D0A1D9E29349D660038624D /* CryptoPrices */,
 				4D0A1DAF29349D670038624D /* CryptoPricesTests */,
 				4D0A1DB929349D670038624D /* CryptoPricesUITests */,
@@ -208,6 +212,7 @@
 			name = CryptoPrices;
 			packageProductDependencies = (
 				4DF0741B293C8D3900E1274D /* Home */,
+				249752BC2941901E003C6238 /* MyCoin */,
 			);
 			productName = CryptoPrices;
 			productReference = 4D0A1D9C29349D660038624D /* CryptoPrices.app */;
@@ -965,6 +970,10 @@
 /* End XCConfigurationList section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		249752BC2941901E003C6238 /* MyCoin */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = MyCoin;
+		};
 		4DF0741B293C8D3900E1274D /* Home */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Home;

--- a/CryptoPrices/Sources/MyCoin/.gitignore
+++ b/CryptoPrices/Sources/MyCoin/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/CryptoPrices/Sources/MyCoin/Package.swift
+++ b/CryptoPrices/Sources/MyCoin/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 5.7
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "MyCoin",
+    platforms: [.iOS(.v15)],
+    products: [
+        .library(
+            name: "MyCoin",
+            targets: ["MyCoin"]
+        )
+    ],
+    dependencies: [
+        .package(name: "Styleguide", path: "../Styleguide")
+    ],
+    targets: [
+        .target(
+            name: "MyCoin",
+            dependencies: [.product(name: "Styleguide", package: "Styleguide")]
+        ),
+        .testTarget(
+            name: "MyCoinTests",
+            dependencies: ["MyCoin"])
+    ]
+)

--- a/CryptoPrices/Sources/MyCoin/README.md
+++ b/CryptoPrices/Sources/MyCoin/README.md
@@ -1,0 +1,3 @@
+# MyCoin
+
+The MyCoin package.

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView.swift
@@ -1,0 +1,29 @@
+//  MyCoinView.swift
+//  MyCoin
+//
+//  Created by Mike Pham on 04/12/2022.
+//
+
+import Styleguide
+import SwiftUI
+
+public struct MyCoinView: View {
+
+    public var body: some View {
+        // TODO: Handle to show correct view in the UI task
+        Text("MyCoin View")
+    }
+
+    public init() {}
+}
+
+#if DEBUG
+struct MyCoinView_Previews: PreviewProvider {
+
+    static var previews: some View {
+        Preview {
+            MyCoinView()
+        }
+    }
+}
+#endif

--- a/CryptoPrices/Sources/MyCoin/Tests/MyCoinTests/MyCoinTests.swift
+++ b/CryptoPrices/Sources/MyCoin/Tests/MyCoinTests/MyCoinTests.swift
@@ -1,0 +1,5 @@
+import XCTest
+@testable import MyCoin
+
+final class MyCoinTests: XCTestCase {
+}


### PR DESCRIPTION
- Close #29

## What happened 👀

- Create `MyCoin` local package for all source files relating to the MyCoin screen.
- Link the `MyCoin` SPM package to the main application for later usage + navigation.

## Insight 📝

Right now, since the scale of the project is small and we have only 2 main screens, the modular package is introduced accordingly per screen. For bigger projects, we should create a package per feature that could contain multiple screens.

## Proof Of Work 📹

- The new `MyCoin` local package is available in the project:
 
![Screenshot 2022-12-08 at 10 32 29](https://user-images.githubusercontent.com/70877098/206350260-25e05b24-a606-4ceb-9276-7945ff8cacb3.png)

- Hard code to show the current `MyCoin` view:

|Light mode preview|Dark mode preview|
|--------------------|-------------------|
|<img width="598" src="https://user-images.githubusercontent.com/70877098/206350468-461afb92-3350-4575-9f53-ac4a3df5c791.jpeg">|<img width="598" src="https://user-images.githubusercontent.com/70877098/206350477-33ee9e84-3a00-400f-98a5-338daafabb5f.jpeg">|
