### PR TITLE
[#7] [UI] Implement the Trending Coin section in the Home screen

### DIFF
--- a/CryptoPrices/Sources/Home/Sources/Home/HomeView.swift
+++ b/CryptoPrices/Sources/Home/Sources/Home/HomeView.swift
@@ -15,6 +15,7 @@ public struct HomeView: View {
                 homeTitle
                 WalletStatisticSection()
                 MyCoinSection()
+                TrendingCoinSection()
             }
         }
         .padding(.top, 24.0)

--- a/CryptoPrices/Sources/Home/Sources/Home/Localization/Strings.swift
+++ b/CryptoPrices/Sources/Home/Sources/Home/Localization/Strings.swift
@@ -32,6 +32,10 @@ internal enum Strings {
       /// Total Coins
       internal static let title = Strings.tr("Localizable", "home.totalCoins.title", fallback: "Total Coins")
     }
+    internal enum TrendingCoins {
+      /// Trending 🔥
+      internal static let title = Strings.tr("Localizable", "home.trendingCoins.title", fallback: "Trending 🔥")
+    }
   }
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length

--- a/CryptoPrices/Sources/Home/Sources/Home/Resources/en.lproj/Localizable.strings
+++ b/CryptoPrices/Sources/Home/Sources/Home/Resources/en.lproj/Localizable.strings
@@ -1,5 +1,6 @@
-"home.title.text" = "Trade Now and Get\nYour Life";
-"home.totalCoins.title" = "Total Coins";
-"home.todayProfit.title" = "Today’s Profit";
 "home.myCoin.title" = "My Coins 😎";
 "home.seeAll.text" = "see all ->";
+"home.title.text" = "Trade Now and Get\nYour Life";
+"home.todayProfit.title" = "Today’s Profit";
+"home.totalCoins.title" = "Total Coins";
+"home.trendingCoins.title" = "Trending 🔥";

--- a/CryptoPrices/Sources/Home/Sources/Home/TrendingCoins/TrendingCoinItemView.swift
+++ b/CryptoPrices/Sources/Home/Sources/Home/TrendingCoins/TrendingCoinItemView.swift
@@ -1,0 +1,81 @@
+//
+//  TrendingCoinItemView.swift
+//
+//  Created by Mike Pham on 15/12/2022.
+//
+
+import Styleguide
+import SwiftUI
+
+struct TrendingCoinItemView: View {
+
+    // TODO: - Remove dummy
+    var percentage = 6.21
+
+    var body: some View {
+        HStack {
+            HStack {
+                coinImage
+                coinInfo
+                Spacer()
+                priceChangePercentage
+            }
+            .padding(8.0)
+        }
+        .frame(height: 68.0)
+        .background(Colors.bgCurrencyItem.swiftUIColor)
+        .cornerRadius(12.0)
+    }
+}
+
+private extension TrendingCoinItemView {
+
+    var coinImage: some View {
+        // TODO: - Remove dummy
+        Images.icBitcoin.swiftUIImage
+            .frame(width: 40.0, height: 40.0)
+            .clipShape(Circle())
+    }
+
+    var coinInfo: some View {
+        // TODO: - Remove dummy
+        VStack(alignment: .leading) {
+            Text("BTC")
+                .foregroundColor(Colors.textBold.swiftUIColor)
+                .font(Fonts.Inter.bold.textStyle(.callout))
+                .padding(.bottom, 4.0)
+
+            Text("Bitcoin")
+                .foregroundColor(Colors.textMedium.swiftUIColor)
+                .font(Fonts.Inter.medium.textStyle(.subheadline))
+        }
+    }
+
+    var priceChangePercentage: some View {
+        // TODO: - Remove dummy
+        HStack {
+            percentage < 0.0
+            ? Images.icArrowDownRed.swiftUIImage
+            : Images.icArrowUpGreen.swiftUIImage
+
+            Text("6.21%")
+                .font(Fonts.Inter.bold.textStyle(.callout))
+                .foregroundColor(
+                    percentage < 0.0
+                    ? Colors.carnation.swiftUIColor
+                    : Colors.guppieGreen.swiftUIColor
+                )
+        }
+    }
+}
+
+#if DEBUG
+struct TrendingCoinItemView_Previews: PreviewProvider {
+
+    static var previews: some View {
+        Preview {
+            TrendingCoinItemView()
+        }
+    }
+}
+#endif

--- a/CryptoPrices/Sources/Home/Sources/Home/TrendingCoins/TrendingCoinSection.swift
+++ b/CryptoPrices/Sources/Home/Sources/Home/TrendingCoins/TrendingCoinSection.swift
@@ -1,0 +1,50 @@
+//
+//  TrendingCoinSection.swift
+//
+//  Created by Mike Pham on 15/12/2022.
+//
+
+import Styleguide
+import SwiftUI
+
+struct TrendingCoinSection: View {
+
+    var body: some View {
+        VStack {
+            HStack {
+                Text(Strings.Home.TrendingCoins.title)
+                    .foregroundColor(Colors.titleMedium.swiftUIColor)
+                    .font(Fonts.Inter.medium.textStyle(.callout))
+
+                Spacer()
+
+                Button(Strings.Home.SeeAll.text) {}
+                    .foregroundColor(Colors.caribbeanGreen.swiftUIColor)
+                    .font(Fonts.Inter.medium.textStyle(.subheadline))
+            }
+            .padding(16.0)
+
+            // TODO: - Remove dummy
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack {
+                    ForEach(0..<2) {_ in
+                        TrendingCoinItemView()
+                            .padding(.vertical, 8.0)
+                    }
+                }
+                .padding(.horizontal, 16.0)
+            }
+        }
+    }
+}
+
+#if DEBUG
+struct TrendingCoinSection_Previews: PreviewProvider {
+
+    static var previews: some View {
+        Preview {
+            TrendingCoinSection()
+        }
+    }
+}
+#endif


### PR DESCRIPTION
- Close #7

## What happened 👀

- Create `TrendingCoinsSection` that includes a section header and a few mock `TrendingCoinsItemView` items.
- Reuse the handling for dark and light modes based on `Assets`.
- Add a new string key for this section title: `home.trendingCoins.title`.

## Insight 📝

- ~The current `swift-gen` library doesn't seem to work properly when the new localized string key is added, it doesn't automatically build and generate the reference for the new key. Right now the `TrendingCoins` enum in the `Strings` file is generated manually instead. A [request](https://github.com/nimblehq/nimble-crypto-ios/pull/40#issuecomment-1352655745) for instructions on how to generate new values or maybe set up an automatic script would be helpful here.~ -> The instructions are provided on the `README.md` page. 🚀
- The data populated is being hard-coded at the moment. We will need to update to use the correct data in the integration task. 💪

## Proof Of Work 📹

Light mode:
<img src="https://user-images.githubusercontent.com/70877098/207802540-3378bb65-b69c-4f59-93fb-7edbee4e8978.PNG" width=400>

Dark mode:
<img src="https://user-images.githubusercontent.com/70877098/207802654-782af27c-1a82-401b-9803-87cf09e013d8.PNG" width=400>

