### PR TITLE
[#13] [UI] As a user, I can see the coin’s current price on the Detail screen

### DIFF
--- a/CryptoPrices/Sources/Data/Tests/RepositoriesTests/CoinRepository/CoinRepositorySpec.swift
+++ b/CryptoPrices/Sources/Data/Tests/RepositoriesTests/CoinRepository/CoinRepositorySpec.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Doan Thieu on 29/11/2022.
 //
-// swiftlint:disable function_body_length closure_body_length superfluous_disable_command
+// swiftlint:disable function_body_length closure_body_length
 
 import DataTestHelpers
 import NetworkCore

--- a/CryptoPrices/Sources/Home/Sources/Home/HomeView/HomeView.swift
+++ b/CryptoPrices/Sources/Home/Sources/Home/HomeView/HomeView.swift
@@ -41,7 +41,7 @@ private extension HomeView {
     var headerView: some View {
         Text(Strings.Home.Title.text)
             .multilineTextAlignment(.center)
-            .font(Fonts.Inter.bold.textStyle(.title2))
+            .font(Fonts.Inter.bold.textStyle(.title))
     }
 }
 

--- a/CryptoPrices/Sources/Home/Sources/Home/MyCoinsSectionView/MyCoinItemView.swift
+++ b/CryptoPrices/Sources/Home/Sources/Home/MyCoinsSectionView/MyCoinItemView.swift
@@ -60,19 +60,19 @@ private extension MyCoinItemView {
     var coinInfo: some View {
         VStack(alignment: .leading) {
             Text(coinItem.symbol)
-                .font(Fonts.Inter.bold.textStyle(.callout))
+                .font(Fonts.Inter.semiBold.textStyle(.body))
                 .foregroundColor(Colors.textBold.swiftUIColor)
                 .padding(.bottom, 4.0)
 
             Text(coinItem.name)
-                .font(Fonts.Inter.medium.textStyle(.subheadline))
+                .font(Fonts.Inter.medium.textStyle(.callout))
                 .foregroundColor(Colors.textMedium.swiftUIColor)
         }
     }
     
     var currentPrice: some View {
         Text(coinItem.currentPrice, format: .dollarCurrency)
-            .font(Fonts.Inter.bold.textStyle(.callout))
+            .font(Fonts.Inter.semiBold.textStyle(.body))
             .foregroundColor(Colors.textBold.swiftUIColor)
     }
     
@@ -83,7 +83,7 @@ private extension MyCoinItemView {
             : Images.icArrowDownRed.swiftUIImage
 
             Text(coinItem.priceChangePercentage, format: .percentage)
-                .font(Fonts.Inter.bold.textStyle(.callout))
+                .font(Fonts.Inter.medium.textStyle(.body))
                 .foregroundColor(
                     coinItem.isPriceUp
                     ? Colors.guppieGreen.swiftUIColor

--- a/CryptoPrices/Sources/Home/Sources/Home/TrendingCoinsSectionView/TrendingCoinItemView.swift
+++ b/CryptoPrices/Sources/Home/Sources/Home/TrendingCoinsSectionView/TrendingCoinItemView.swift
@@ -42,12 +42,12 @@ private extension TrendingCoinItemView {
         VStack(alignment: .leading) {
             Text("BTC")
                 .foregroundColor(Colors.textBold.swiftUIColor)
-                .font(Fonts.Inter.bold.textStyle(.callout))
+                .font(Fonts.Inter.semiBold.textStyle(.body))
                 .padding(.bottom, 4.0)
 
             Text("Bitcoin")
                 .foregroundColor(Colors.textMedium.swiftUIColor)
-                .font(Fonts.Inter.medium.textStyle(.subheadline))
+                .font(Fonts.Inter.medium.textStyle(.callout))
         }
     }
 
@@ -59,7 +59,7 @@ private extension TrendingCoinItemView {
             : Images.icArrowUpGreen.swiftUIImage
 
             Text(percentage, format: .percentage)
-                .font(Fonts.Inter.bold.textStyle(.callout))
+                .font(Fonts.Inter.medium.textStyle(.body))
                 .foregroundColor(
                     percentage < 0.0
                     ? Colors.carnation.swiftUIColor

--- a/CryptoPrices/Sources/Home/Sources/Home/WalletStatisticSectionView/WalletStatisticSection.swift
+++ b/CryptoPrices/Sources/Home/Sources/Home/WalletStatisticSectionView/WalletStatisticSection.swift
@@ -44,12 +44,12 @@ private extension WalletStatisticSection {
             VStack(alignment: .leading, spacing: 8.0) {
                 Text(Strings.Home.TotalCoins.title)
                     .foregroundColor(Colors.lightSilver.swiftUIColor)
-                    .font(Fonts.Inter.medium.textStyle(.callout))
+                    .font(Fonts.Inter.medium.textStyle(.body))
 
                 // TODO: Remove hard-coded data
                 Text(7_273_291, format: .dollarCurrency)
                     .foregroundColor(.white)
-                    .font(Fonts.Inter.bold.textStyle(.title2))
+                    .font(Fonts.Inter.semiBold.textStyle(.title))
             }
 
             Spacer()
@@ -61,12 +61,12 @@ private extension WalletStatisticSection {
             VStack(alignment: .leading, spacing: 8.0) {
                 Text(Strings.Home.TodayProfit.title)
                     .foregroundColor(Colors.lightSilver.swiftUIColor)
-                    .font(Fonts.Inter.medium.textStyle(.callout))
+                    .font(Fonts.Inter.medium.textStyle(.body))
 
                 // TODO: Remove hard-coded data
                 Text(193.28, format: .dollarCurrency)
                     .foregroundColor(.white)
-                    .font(Fonts.Inter.bold.textStyle(.title2))
+                    .font(Fonts.Inter.semiBold.textStyle(.title))
             }
 
             Spacer()
@@ -76,6 +76,7 @@ private extension WalletStatisticSection {
                     Images.icArrowUpGreen.swiftUIImage
                     // TODO: Remove hard-coded data
                     Text(2.41, format: .percentage)
+                        .font(Fonts.Inter.medium.textStyle(.body))
                 }
             })
             .padding(EdgeInsets(top: 8.0, leading: 10.0, bottom: 8.0, trailing: 10.0))

--- a/CryptoPrices/Sources/Home/Tests/HomeTests/HomeViewModelSpec.swift
+++ b/CryptoPrices/Sources/Home/Tests/HomeTests/HomeViewModelSpec.swift
@@ -1,4 +1,4 @@
-// swiftlint:disable function_body_length closure_body_length superfluous_disable_command
+// swiftlint:disable closure_body_length
 
 import DomainTestHelpers
 import Nimble

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/CurrentPriceSectionView/CurrentPriceSection.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/CurrentPriceSectionView/CurrentPriceSection.swift
@@ -1,0 +1,47 @@
+//
+//  CurrentPriceSection.swift
+//  MyCoin
+//
+//  Created by Minh Pham on 22/12/2022.
+//
+
+import Styleguide
+import SwiftUI
+
+struct CurrentPriceSection: View {
+
+    var body: some View {
+        VStack(spacing: 8.0) {
+            // TODO: - Remove dummy
+            Images.icEth.swiftUIImage
+                .frame(width: 60.0, height: 60.0)
+                .clipShape(Circle())
+
+            VStack(spacing: 4.0) {
+                // TODO: Remove hard-coded data
+                Text(7_273_291, format: .dollarCurrency)
+                    .foregroundColor(.white)
+                    .font(Fonts.Inter.bold.textStyle(.title2))
+
+                Button(action: {}, label: {
+                    HStack {
+                        Images.icArrowUpGreen.swiftUIImage
+                        Text(2.41, format: .percentage) // TODO: Remove hard-coded data
+                    }
+                })
+            }
+        }
+        .padding(.vertical, 8.0)
+    }
+}
+
+#if DEBUG
+struct CurrentPriceSection_Previews: PreviewProvider {
+
+    static var previews: some View {
+        Preview {
+            CurrentPriceSection()
+        }
+    }
+}
+#endif

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/CurrentPriceSectionView/CurrentPriceSection.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/CurrentPriceSectionView/CurrentPriceSection.swift
@@ -14,24 +14,35 @@ struct CurrentPriceSection: View {
         VStack(spacing: 8.0) {
             // TODO: - Remove dummy
             Images.icEth.swiftUIImage
+                .resizable()
+                .aspectRatio(contentMode: .fit)
                 .frame(width: 60.0, height: 60.0)
                 .clipShape(Circle())
 
             VStack(spacing: 4.0) {
                 // TODO: Remove hard-coded data
                 Text(7_273_291, format: .dollarCurrency)
-                    .foregroundColor(.white)
-                    .font(Fonts.Inter.bold.textStyle(.title2))
+                    .foregroundColor(Colors.textBold.swiftUIColor)
+                    .font(Fonts.Inter.semiBold.textStyle(.title))
+                    .frame(height: 34.0)
 
                 Button(action: {}, label: {
                     HStack {
                         Images.icArrowUpGreen.swiftUIImage
-                        Text(2.41, format: .percentage) // TODO: Remove hard-coded data
+                        // TODO: Remove hard-coded data
+                        Text(2.41, format: .percentage)
+                            .font(Fonts.Inter.medium.textStyle(.callout))
+                        
                     }
                 })
+                .padding(EdgeInsets(top: 8.0, leading: 10.0, bottom: 8.0, trailing: 10.0))
+                .foregroundColor(Colors.guppieGreen.swiftUIColor)
+                .background(Colors.scandal.swiftUIColor)
+                .cornerRadius(20.0)
             }
         }
         .padding(.vertical, 8.0)
+        .frame(maxWidth: .infinity)
     }
 }
 

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
@@ -13,7 +13,7 @@ public struct MyCoinView: View {
 
     public var body: some View {
         NavigationView {
-            CurrentPriceSection()
+            contentView
                 .navigationBarBackButtonHidden(true)
                 .navigationBarItems(leading: backButton, trailing: likeButton)
                 .navigationTitle("Ethereum") // TODO: Remove dummy
@@ -25,6 +25,15 @@ public struct MyCoinView: View {
 }
 
 private extension MyCoinView {
+
+    var contentView: some View {
+        ScrollView {
+            CurrentPriceSection()
+        }
+        .clipped(antialiased: false)
+        .frame(maxHeight: .infinity)
+        .background(Colors.bgMain.swiftUIColor)
+    }
 
     var backButton: some View {
         Button {

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
@@ -12,12 +12,11 @@ public struct MyCoinView: View {
     @EnvironmentObject var myCoinState: MyCoinState
 
     public var body: some View {
-        // TODO: Remove dummy
         NavigationView {
-            Text("MyCoin View")
+            CurrentPriceSection()
                 .navigationBarBackButtonHidden(true)
                 .navigationBarItems(leading: backButton, trailing: likeButton)
-                .navigationTitle("Ethereum")
+                .navigationTitle("Ethereum") // TODO: Remove dummy
                 .navigationBarTitleDisplayMode(.inline)
         }
     }

--- a/CryptoPrices/Sources/Styleguide/Sources/Styleguide/Generated/Colors.swift
+++ b/CryptoPrices/Sources/Styleguide/Sources/Styleguide/Generated/Colors.swift
@@ -29,6 +29,7 @@ public enum Colors {
   public static let guppieGreen = ColorAsset(name: "guppieGreen")
   public static let lightSilver = ColorAsset(name: "lightSilver")
   public static let metallicSeaweed = ColorAsset(name: "metallicSeaweed")
+  public static let scandal = ColorAsset(name: "scandal")
   public static let textBold = ColorAsset(name: "text_bold")
   public static let textMedium = ColorAsset(name: "text_medium")
   public static let tiffanyBlue = ColorAsset(name: "tiffanyBlue")

--- a/CryptoPrices/Sources/Styleguide/Sources/Styleguide/Generated/Images.swift
+++ b/CryptoPrices/Sources/Styleguide/Sources/Styleguide/Generated/Images.swift
@@ -26,8 +26,8 @@ public enum Images {
   public static let icArrowUpGreen = ImageAsset(name: "ic_arrow_up_green")
   public static let icBack = ImageAsset(name: "ic_back")
   public static let icBitcoin = ImageAsset(name: "ic_bitcoin")
-  public static let icHeart = ImageAsset(name: "ic_heart")
   public static let icEth = ImageAsset(name: "ic_eth")
+  public static let icHeart = ImageAsset(name: "ic_heart")
 }
 // swiftlint:enable identifier_name line_length nesting type_body_length type_name
 

--- a/CryptoPrices/Sources/Styleguide/Sources/Styleguide/Resources/Assets/Colors.xcassets/scandal.colorset/Contents.json
+++ b/CryptoPrices/Sources/Styleguide/Sources/Styleguide/Resources/Assets/Colors.xcassets/scandal.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEC",
+          "green" : "0xFB",
+          "red" : "0xDB"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
- Close #13

## What happened 👀

- Implement the current price section for the `MyCoin` screen.
- Add a base scroll view for this section to support scrolling with more content in the future. 

## Insight 📝

- Currently, some of the current set fonts and sizes are incorrect compared to the [designs](https://www.figma.com/file/Iy9eg3ym29pkKGsD5X48O7/Crypto-App-(Community)?node-id=3%3A107&t=RTdnDWc1ccmZrfsh-0) that the weight should be `semiBold` and `medium` but we are using `bold` most of the time. Here is the `Inter` font's weight for more reference: https://fonts.google.com/specimen/Inter -> So a refactor for updating to consistent fonts and sizes usage compared with the design is applied for the new screen and the existing screens also 🚀

- Regarding the new color `#DBFBEC`, when trying to get a name from this [source](https://www.color-name.com/hex/d6f5f3), it provides the same name -`water` as with the color - `#D6F5F3`. As a result, I am using the name provided by this [source](https://chir.ag/projects/name-that-color/#DBFBE) instead because it has better naming differentiation between small changes in the color codes. 🙏

- Update the lint to clean up `superfluous_disable_command` since my local Swiftlint is updated to the latest version `0.50.3` and it is working properly now 🚀

## Proof Of Work 📹

- Dark mode:
<img src="https://user-images.githubusercontent.com/70877098/209074098-7bb46d3b-669c-4221-ba9e-c99854d90682.jpeg" width="400">

- Light mode:
<img src="https://user-images.githubusercontent.com/70877098/209074106-6234e160-234c-426b-92b8-da6149f68573.jpeg" width="400">
