### PR TITLE
[#47] [Chore] [Spike] Cache remote Swift packages build-artifacts on CI

### DIFF
--- a/.github/workflows/automatic_pull_request_review.yml
+++ b/.github/workflows/automatic_pull_request_review.yml
@@ -14,11 +14,13 @@ jobs:
       with:
         access_token: ${{ github.token }}
 
-    - uses: actions/checkout@v3
+    - name: Checkout
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
-    - uses: actions/cache@v3
+    - name: Cache Ruby gems
+      uses: actions/cache@v3
       id: bunlderCache
       with:
         path: vendor/bundle
@@ -26,7 +28,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gems-
 
-    - name: Cache packages
+    - name: Cache Swift packages
       uses: actions/cache@v3
       with:
         path: SourcePackages

--- a/.github/workflows/automatic_pull_request_review.yml
+++ b/.github/workflows/automatic_pull_request_review.yml
@@ -26,7 +26,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gems-
 
-    - name: Restore SPM
+    - name: Cache packages
       uses: actions/cache@v3
       with:
         path: SourcePackages
@@ -44,12 +44,6 @@ jobs:
       run: bundle exec fastlane buildAndTest
       env:
         CI: true
-        
-    - name: Cache SPM
-      uses: actions/cache@v3
-      with:
-        path: SourcePackages
-        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
 
     - name: Clean up previous code coverage report
       run: bundle exec fastlane cleanUpOutput

--- a/.github/workflows/automatic_pull_request_review.yml
+++ b/.github/workflows/automatic_pull_request_review.yml
@@ -26,6 +26,14 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gems-
 
+    - name: Restore SPM
+      uses: actions/cache@v3
+      with:
+        path: SourcePackages
+        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-spm-
+
     - name: Setup
       run: make setup
 
@@ -36,6 +44,12 @@ jobs:
       run: bundle exec fastlane buildAndTest
       env:
         CI: true
+        
+    - name: Cache SPM
+      uses: actions/cache@v3
+      with:
+        path: SourcePackages
+        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
 
     - name: Clean up previous code coverage report
       run: bundle exec fastlane cleanUpOutput

--- a/.github/workflows/deploy_Firebase.yml
+++ b/.github/workflows/deploy_Firebase.yml
@@ -15,7 +15,8 @@ jobs:
       with:
         access_token: ${{ github.token }}
 
-    - uses: actions/checkout@v3
+    - name: Checkout
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -29,7 +30,7 @@ jobs:
         yarn add firebase-tools
         echo "$(yarn global bin)" >> $GITHUB_PATH
 
-    - name: Cache SPM
+    - name: Cache Swift packages
       uses: actions/cache@v3
       with:
         path: SourcePackages

--- a/.github/workflows/deploy_Firebase.yml
+++ b/.github/workflows/deploy_Firebase.yml
@@ -29,7 +29,7 @@ jobs:
         yarn add firebase-tools
         echo "$(yarn global bin)" >> $GITHUB_PATH
 
-    - name: Restore SPM
+    - name: Cache SPM
       uses: actions/cache@v3
       with:
         path: SourcePackages

--- a/.github/workflows/deploy_Firebase.yml
+++ b/.github/workflows/deploy_Firebase.yml
@@ -28,7 +28,15 @@ jobs:
       run: |
         yarn add firebase-tools
         echo "$(yarn global bin)" >> $GITHUB_PATH
-            
+
+    - name: Restore SPM
+      uses: actions/cache@v3
+      with:
+        path: SourcePackages
+        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-spm-
+
     - name: Setup
       run: make setup
 

--- a/.github/workflows/deploy_Release_Firebase.yml
+++ b/.github/workflows/deploy_Release_Firebase.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-    - name: Restore SPM
+    - name: Cache SPM
       uses: actions/cache@v3
       with:
         path: SourcePackages

--- a/.github/workflows/deploy_Release_Firebase.yml
+++ b/.github/workflows/deploy_Release_Firebase.yml
@@ -23,7 +23,15 @@ jobs:
       uses: webfactory/ssh-agent@v0.5.4
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-            
+
+    - name: Restore SPM
+      uses: actions/cache@v3
+      with:
+        path: SourcePackages
+        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-spm-
+
     - name: Setup
       run: make setup
 

--- a/.github/workflows/deploy_Release_Firebase.yml
+++ b/.github/workflows/deploy_Release_Firebase.yml
@@ -15,7 +15,8 @@ jobs:
       with:
         access_token: ${{ github.token }}
 
-    - uses: actions/checkout@v3
+    - name: Checkout
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -24,7 +25,7 @@ jobs:
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-    - name: Cache SPM
+    - name: Cache Swift packages
       uses: actions/cache@v3
       with:
         path: SourcePackages

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ fastlane/FastlaneRunner
 # Bundler
 .bundle
 vendor/bundle
+
+# SourcePackages folder
+SourcePackages

--- a/CryptoPrices.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CryptoPrices.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,79 +1,77 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "CwlCatchException",
-        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
-        "state": {
-          "branch": null,
-          "revision": "35f9e770f54ce62dd8526470f14c6e137cef3eea",
-          "version": "2.1.1"
-        }
-      },
-      {
-        "package": "CwlPreconditionTesting",
-        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
-        "state": {
-          "branch": null,
-          "revision": "c21f7bab5ca8eee0a9998bbd17ca1d0eb45d4688",
-          "version": "2.1.0"
-        }
-      },
-      {
-        "package": "Factory",
-        "repositoryURL": "https://github.com/hmlongco/Factory",
-        "state": {
-          "branch": null,
-          "revision": "ca5788b8621b185a0fbe6ef05bb9a73b3ef2833f",
-          "version": "1.2.9"
-        }
-      },
-      {
-        "package": "Nimble",
-        "repositoryURL": "https://github.com/Quick/Nimble",
-        "state": {
-          "branch": null,
-          "revision": "b7f6c49acdb247e3158198c5448b38c3cc595533",
-          "version": "11.2.1"
-        }
-      },
-      {
-        "package": "Pilot",
-        "repositoryURL": "https://github.com/Thieurom/Pilot",
-        "state": {
-          "branch": null,
-          "revision": "d0c990223f3447fd912ae716d03676fd1db714af",
-          "version": "0.5.1"
-        }
-      },
-      {
-        "package": "Quick",
-        "repositoryURL": "https://github.com/Quick/Quick",
-        "state": {
-          "branch": null,
-          "revision": "16910e406be96e08923918315388c3e989deac9e",
-          "version": "6.1.0"
-        }
-      },
-      {
-        "package": "ShowTime",
-        "repositoryURL": "https://github.com/KaneCheshire/ShowTime",
-        "state": {
-          "branch": null,
-          "revision": "f4e976931fc5f9b7a7d011f40c62a250c4ff53ab",
-          "version": "2.5.3"
-        }
-      },
-      {
-        "package": "Wormholy",
-        "repositoryURL": "https://github.com/ipavlidakis/Wormholy",
-        "state": {
-          "branch": "master",
-          "revision": "fa6cba3377498701c67720d4911d33b36a5d0bab",
-          "version": null
-        }
+  "pins" : [
+    {
+      "identity" : "cwlcatchexception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlCatchException.git",
+      "state" : {
+        "revision" : "35f9e770f54ce62dd8526470f14c6e137cef3eea",
+        "version" : "2.1.1"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "cwlpreconditiontesting",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+      "state" : {
+        "revision" : "c21f7bab5ca8eee0a9998bbd17ca1d0eb45d4688",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "factory",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/hmlongco/Factory",
+      "state" : {
+        "revision" : "ca5788b8621b185a0fbe6ef05bb9a73b3ef2833f",
+        "version" : "1.2.9"
+      }
+    },
+    {
+      "identity" : "nimble",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Quick/Nimble",
+      "state" : {
+        "revision" : "b7f6c49acdb247e3158198c5448b38c3cc595533",
+        "version" : "11.2.1"
+      }
+    },
+    {
+      "identity" : "pilot",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Thieurom/Pilot",
+      "state" : {
+        "revision" : "d0c990223f3447fd912ae716d03676fd1db714af",
+        "version" : "0.5.1"
+      }
+    },
+    {
+      "identity" : "quick",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Quick/Quick",
+      "state" : {
+        "revision" : "16910e406be96e08923918315388c3e989deac9e",
+        "version" : "6.1.0"
+      }
+    },
+    {
+      "identity" : "showtime",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/KaneCheshire/ShowTime",
+      "state" : {
+        "revision" : "f4e976931fc5f9b7a7d011f40c62a250c4ff53ab",
+        "version" : "2.5.3"
+      }
+    },
+    {
+      "identity" : "wormholy",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ipavlidakis/Wormholy",
+      "state" : {
+        "branch" : "master",
+        "revision" : "fa6cba3377498701c67720d4911d33b36a5d0bab"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/fastlane/Constants/Constant.swift
+++ b/fastlane/Constants/Constant.swift
@@ -30,6 +30,7 @@ enum Constant {
     static let derivedDataPath = "\(outputPath)/DerivedData"
     static let projectPath: String = "./\(projectName).xcodeproj"
     static let testOutputDirectoryPath = "./fastlane/test_output"
+    static let clonedSourcePackagesPath = "SourcePackages"
 
     // MARK: Platform
 

--- a/fastlane/Helpers/Build.swift
+++ b/fastlane/Helpers/Build.swift
@@ -51,8 +51,7 @@ enum Build {
             ]),
             buildPath: .userDefined(Constant.buildPath),
             derivedDataPath: .userDefined(Constant.derivedDataPath),
-            xcodebuildFormatter: "xcbeautify",
-            clonedSourcePackagesPath: .userDefined("SourcePackages")
+            xcodebuildFormatter: "xcbeautify"
         )
     }
 }

--- a/fastlane/Helpers/Build.swift
+++ b/fastlane/Helpers/Build.swift
@@ -51,7 +51,8 @@ enum Build {
             ]),
             buildPath: .userDefined(Constant.buildPath),
             derivedDataPath: .userDefined(Constant.derivedDataPath),
-            xcodebuildFormatter: "xcbeautify"
+            xcodebuildFormatter: "xcbeautify",
+            clonedSourcePackagesPath: .userDefined("SourcePackages")
         )
     }
 }

--- a/fastlane/Helpers/Build.swift
+++ b/fastlane/Helpers/Build.swift
@@ -51,7 +51,8 @@ enum Build {
             ]),
             buildPath: .userDefined(Constant.buildPath),
             derivedDataPath: .userDefined(Constant.derivedDataPath),
-            xcodebuildFormatter: "xcbeautify"
+            xcodebuildFormatter: "xcbeautify",
+            clonedSourcePackagesPath: .userDefined(Constant.clonedSourcePackagesPath)
         )
     }
 }

--- a/fastlane/Helpers/Test.swift
+++ b/fastlane/Helpers/Test.swift
@@ -21,6 +21,7 @@ enum Test {
             outputDirectory: Constant.testOutputDirectoryPath,
             xcodebuildFormatter: "xcbeautify",
             resultBundle: .userDefined(true),
+            clonedSourcePackagesPath: .userDefined(Constant.clonedSourcePackagesPath),
             failBuild: .userDefined(false)
         )
     }

--- a/fastlane/Helpers/Test.swift
+++ b/fastlane/Helpers/Test.swift
@@ -21,6 +21,7 @@ enum Test {
             outputDirectory: Constant.testOutputDirectoryPath,
             xcodebuildFormatter: "xcbeautify",
             resultBundle: .userDefined(true),
+            clonedSourcePackagesPath: .userDefined("SourcePackages"),
             failBuild: .userDefined(false)
         )
     }

--- a/fastlane/Helpers/Test.swift
+++ b/fastlane/Helpers/Test.swift
@@ -21,7 +21,6 @@ enum Test {
             outputDirectory: Constant.testOutputDirectoryPath,
             xcodebuildFormatter: "xcbeautify",
             resultBundle: .userDefined(true),
-            clonedSourcePackagesPath: .userDefined("SourcePackages"),
             failBuild: .userDefined(false)
         )
     }


### PR DESCRIPTION
- Close #47

## What happened 👀

- Speed up the build process when running GitHub actions by using the cache to restore and save the Swift packages build artifacts instead of fetching those dependencies every CI-running trigger.

## Insight 📝

- `clonedSourcePackagesDirPath` flag in `scan` and `build_app` - is an `xcodebuild build` command option specifies the directory to which remote source packages are fetched or expected to be found.

The flow of caching:
 1. Restoring cache
 2. Build
 3. Saving cache

## Proof Of Work 📹

<details>
<summary>Build and Test</summary>
<be>
Using cache speeds up build up to ~1min.

![Screenshot 2022-12-26 at 10 05 48](https://user-images.githubusercontent.com/25881847/209494580-dc8d568b-cabd-45c3-869b-2069c39a2bc7.png)

=> [Job with caching](https://github.com/nimblehq/nimble-crypto-ios/actions/runs/3776854252)
=> [Job without caching](https://github.com/nimblehq/nimble-crypto-ios/actions/runs/3776813587)

![Screenshot 2022-12-26 at 10 03 37](https://user-images.githubusercontent.com/25881847/209494454-faa7f5e5-901b-4c6f-936a-1e0ac01cbea0.png)

=> [Job with caching](https://github.com/nimblehq/nimble-crypto-ios/actions/runs/3776490498)
=> [Job without caching](https://github.com/nimblehq/nimble-crypto-ios/actions/runs/3774802317)

Dependencies change when we add a lib (Kingfisher, for example). On [this job](https://github.com/nimblehq/nimble-crypto-ios/actions/runs/3776626724/jobs/6420007037):

![Screenshot 2022-12-26 at 10 10 39](https://user-images.githubusercontent.com/25881847/209495034-8dac8206-0073-4df3-b1b7-2e0e4e17c37c.png)

</details>

<details>
<summary>Deploy Firebase</summary>
<be>
On [this job](https://github.com/nimblehq/nimble-crypto-ios/actions/runs/3778923046/jobs/6423842708):

![Screenshot 2022-12-26 at 11 28 23](https://user-images.githubusercontent.com/25881847/209499948-cdc65bf3-2f3f-477e-8ef3-e2995e466c41.png)

</details>





