### PR TITLE
[#76] [Chore] Update SourceryPlugin to clear previously-generated codes before generating new one

### DIFF
--- a/CryptoPrices/Sources/BuildTools/Plugins/SourceryPlugin/SourceryPlugin.swift
+++ b/CryptoPrices/Sources/BuildTools/Plugins/SourceryPlugin/SourceryPlugin.swift
@@ -16,9 +16,22 @@ struct SourceryPlugin: BuildToolPlugin {
             return []
         }
 
-        let sourceryExecutable = try context.tool(named: "sourcery")
         let generatedDirectory = context.pluginWorkDirectory.appending("SourceryGenerated")
 
+        // Command to remove the previously-generated codes
+        let clearCommand = Command.prebuildCommand(
+            displayName: "Clear previously-generated data",
+            executable: .init("/bin/rm"),
+            arguments: [
+                "-rf",
+                generatedDirectory
+            ],
+            outputFilesDirectory: generatedDirectory
+        )
+
+        let sourceryExecutable = try context.tool(named: "sourcery")
+
+        // Command to generate codes from latest changes
         let sourceryCommand = Command.prebuildCommand(
             displayName: "Generate mocked types for \(target) target",
             executable: sourceryExecutable.path,
@@ -36,6 +49,6 @@ struct SourceryPlugin: BuildToolPlugin {
             outputFilesDirectory: generatedDirectory
         )
 
-        return [sourceryCommand]
+        return [clearCommand, sourceryCommand]
     }
 }


### PR DESCRIPTION
- Close #76

## What happened 👀

- Add a command to clear previously-generated codes for `SourceryPlugin`

## Insight 📝
SPM plugin works well for stuff we usually done using bash script.

## Proof Of Work 📹

The buildlog shows "Clear previously-grnerated data" as part of SourceryPlugin running.
<img width="1008" alt="Screenshot 2023-01-02 at 20 41 43" src="https://user-images.githubusercontent.com/17972674/210239355-16ceef2a-4319-4382-b902-2c01631d6ef9.png">
