### PR TITLE
[#8] [Integrate] As a user, I can see Trending coins on the Home screen

### DIFF
--- a/CryptoPrices/Sources/App/DependenciesInjection/Container+Injection.swift
+++ b/CryptoPrices/Sources/App/DependenciesInjection/Container+Injection.swift
@@ -24,7 +24,10 @@ extension Container {
 
     // ViewModels
     static let homeViewModel = Factory {
-        HomeViewModel(myCoinsUseCase: myCoinsUseCase.callAsFunction())
+        HomeViewModel(
+            myCoinsUseCase: myCoinsUseCase.callAsFunction(),
+            trendingCoinsUseCase: trendingCoinsUseCase.callAsFunction()
+        )
     }
 
     // Repositories
@@ -35,5 +38,8 @@ extension Container {
     // UseCases
     static let myCoinsUseCase = Factory<MyCoinsUseCaseProtocol> {
         MyCoinsUseCase(repository: coinRepository.callAsFunction())
+    }
+    static let trendingCoinsUseCase = Factory<TrendingCoinsUseCaseProtocol> {
+        TrendingCoinsUseCase(repository: coinRepository.callAsFunction())
     }
 }

--- a/CryptoPrices/Sources/Data/Sources/NetworkExtension/CoinRoute.swift
+++ b/CryptoPrices/Sources/Data/Sources/NetworkExtension/CoinRoute.swift
@@ -51,8 +51,7 @@ extension CoinRoute: Route {
 
     public var parameterEncoding: ParameterEncoding? {
         switch self {
-        case .myCoins, .chart: return .url
-        case .trendingCoins: return .json
+        case .myCoins, .chart, .trendingCoins: return .url
             // TODO: Update when implement
         default:
             return nil

--- a/CryptoPrices/Sources/Data/Sources/NetworkExtension/CoinRoute.swift
+++ b/CryptoPrices/Sources/Data/Sources/NetworkExtension/CoinRoute.swift
@@ -9,7 +9,7 @@ import Foundation
 import PilotType
 
 public enum CoinRoute {
-
+    
     // TODO: Update when implement
     case myCoins(MyCoinsParameters)
     case trendingCoins(TrendingCoinsParameters)
@@ -18,10 +18,10 @@ public enum CoinRoute {
 }
 
 extension CoinRoute: Route {
-
+    
     // swiftlint:disable:next force_unwrapping
     public var baseURL: URL { .init(string: "https://api.coingecko.com/api/v3")! }
-
+    
     public var path: String {
         switch self {
         case .myCoins, .trendingCoins: return "/coins/markets"
@@ -29,13 +29,13 @@ extension CoinRoute: Route {
         case let .coinDetail(id): return "/coins/\(id)"
         }
     }
-
+    
     public var httpMethod: HttpMethod { .get }
-
+    
     public var httpHeaders: HttpHeaders {
         ["Content-Type": "application/json"]
     }
-
+    
     public var parameters: Parameters? {
         switch self {
         case let .myCoins(parameters): return parameters.encoded()
@@ -48,11 +48,10 @@ extension CoinRoute: Route {
         default: return nil
         }
     }
-
+    
     public var parameterEncoding: ParameterEncoding? {
         switch self {
         case .myCoins, .chart, .trendingCoins: return .url
-            // TODO: Update when implement
         default:
             return nil
         }

--- a/CryptoPrices/Sources/Data/Sources/NetworkExtension/CoinRoute.swift
+++ b/CryptoPrices/Sources/Data/Sources/NetworkExtension/CoinRoute.swift
@@ -9,7 +9,7 @@ import Foundation
 import PilotType
 
 public enum CoinRoute {
-    
+
     // TODO: Update when implement
     case myCoins(MyCoinsParameters)
     case trendingCoins(TrendingCoinsParameters)
@@ -18,10 +18,10 @@ public enum CoinRoute {
 }
 
 extension CoinRoute: Route {
-    
+
     // swiftlint:disable:next force_unwrapping
     public var baseURL: URL { .init(string: "https://api.coingecko.com/api/v3")! }
-    
+
     public var path: String {
         switch self {
         case .myCoins, .trendingCoins: return "/coins/markets"
@@ -29,13 +29,13 @@ extension CoinRoute: Route {
         case let .coinDetail(id): return "/coins/\(id)"
         }
     }
-    
+
     public var httpMethod: HttpMethod { .get }
-    
+
     public var httpHeaders: HttpHeaders {
         ["Content-Type": "application/json"]
     }
-    
+
     public var parameters: Parameters? {
         switch self {
         case let .myCoins(parameters): return parameters.encoded()
@@ -48,7 +48,7 @@ extension CoinRoute: Route {
         default: return nil
         }
     }
-    
+
     public var parameterEncoding: ParameterEncoding? {
         switch self {
         case .myCoins, .chart, .trendingCoins: return .url

--- a/CryptoPrices/Sources/Domain/Sources/DomainTestHelpers/Mocks/MockCoin.swift
+++ b/CryptoPrices/Sources/Domain/Sources/DomainTestHelpers/Mocks/MockCoin.swift
@@ -24,10 +24,10 @@ public extension MockCoin {
 
     // swiftlint:disable force_unwrapping
     static var single = MockCoin(
-        id: "mock",
-        symbol: "mockcoin",
-        name: "MockCoin",
-        image: URL(string: "/")!,
+        id: "bitcoin",
+        symbol: "btc",
+        name: "Bitcoin",
+        image: URL(string: "https://assets.coingecko.com/coins/images/1/large/bitcoin.png?1547033579")!,
         currentPrice: 12.34,
         marketCap: 567.89,
         priceChangePercentage24H: 2.34,

--- a/CryptoPrices/Sources/Home/Sources/Home/HomeView/HomeView.swift
+++ b/CryptoPrices/Sources/Home/Sources/Home/HomeView/HomeView.swift
@@ -16,7 +16,7 @@ public struct HomeView: View {
                 headerView
                 WalletStatisticSection()
                 MyCoinSection(coins: viewModel.myCoins)
-                TrendingCoinSection()
+                TrendingCoinSection(coins: viewModel.trendingCoins)
             }
         }
         .padding(.top, 24.0)
@@ -25,6 +25,7 @@ public struct HomeView: View {
         .background(Colors.bgMain.swiftUIColor)
         .task {
             await viewModel.fetchMyCoins()
+            await viewModel.fetchTrendingCoins()
         }
     }
 
@@ -51,7 +52,12 @@ struct HomeView_Previews: PreviewProvider {
 
     static var previews: some View {
         Preview {
-            HomeView(viewModel: HomeViewModel(myCoinsUseCase: MockMyCoinsUseCaseProtocol()))
+            HomeView(viewModel:
+                        HomeViewModel(
+                            myCoinsUseCase: MockMyCoinsUseCaseProtocol(),
+                            trendingCoinsUseCase: MockTrendingCoinsUseCaseProtocol()
+                        )
+            )
         }
     }
 }

--- a/CryptoPrices/Sources/Home/Sources/Home/HomeView/HomeView.swift
+++ b/CryptoPrices/Sources/Home/Sources/Home/HomeView/HomeView.swift
@@ -16,7 +16,9 @@ public struct HomeView: View {
                 headerView
                 WalletStatisticSection()
                 MyCoinSection(coins: viewModel.myCoins)
-                TrendingCoinSection(coins: viewModel.trendingCoins)
+                if !viewModel.trendingCoins.isEmpty {
+                    TrendingCoinSection(coins: viewModel.trendingCoins)
+                }
             }
         }
         .padding(.top, 24.0)
@@ -51,14 +53,11 @@ import DomainTestHelpers
 struct HomeView_Previews: PreviewProvider {
 
     static var previews: some View {
-        Preview {
-            HomeView(viewModel:
-                        HomeViewModel(
-                            myCoinsUseCase: MockMyCoinsUseCaseProtocol(),
-                            trendingCoinsUseCase: MockTrendingCoinsUseCaseProtocol()
-                        )
-            )
-        }
+        let homeViewModel = HomeViewModel(
+            myCoinsUseCase: MockMyCoinsUseCaseProtocol(),
+            trendingCoinsUseCase: MockTrendingCoinsUseCaseProtocol()
+        )
+        return Preview { HomeView(viewModel: homeViewModel) }
     }
 }
 #endif

--- a/CryptoPrices/Sources/Home/Sources/Home/HomeView/HomeViewModel.swift
+++ b/CryptoPrices/Sources/Home/Sources/Home/HomeView/HomeViewModel.swift
@@ -34,6 +34,8 @@ import UseCaseProtocol
     }
 
     public func fetchTrendingCoins() async {
+        // The list of trending coins are provided as per the requirement from this backend task:
+        // https://github.com/nimblehq/nimble-crypto-ios/issues/9
         let trendingCoinIDs = [
             "bitcoin",
             "ethereum",

--- a/CryptoPrices/Sources/Home/Sources/Home/HomeView/HomeViewModel.swift
+++ b/CryptoPrices/Sources/Home/Sources/Home/HomeView/HomeViewModel.swift
@@ -11,17 +11,44 @@ import UseCaseProtocol
 @MainActor public final class HomeViewModel: ObservableObject {
 
     private let myCoinsUseCase: MyCoinsUseCaseProtocol
+    private let trendingCoinsUseCase: TrendingCoinsUseCaseProtocol
 
     @Published public private(set) var myCoins: [MyCoinItem] = []
+    @Published public private(set) var trendingCoins: [TrendingCoinItem] = []
 
-    public init(myCoinsUseCase: MyCoinsUseCaseProtocol) {
+    public init(
+        myCoinsUseCase: MyCoinsUseCaseProtocol,
+        trendingCoinsUseCase: TrendingCoinsUseCaseProtocol
+    ) {
         self.myCoinsUseCase = myCoinsUseCase
+        self.trendingCoinsUseCase = trendingCoinsUseCase
     }
 
     public func fetchMyCoins() async {
         do {
             myCoins = try await myCoinsUseCase.execute()
                 .map(MyCoinItem.init)
+        } catch {
+            // TODO: Handle errors
+        }
+    }
+
+    public func fetchTrendingCoins() async {
+        let trendingCoinIDs = [
+            "bitcoin",
+            "ethereum",
+            "binancecoin",
+            "ripple",
+            "cardano",
+            "solana",
+            "polkadot",
+            "near",
+            "tron",
+            "dogecoin"
+        ]
+        do {
+            trendingCoins = try await trendingCoinsUseCase.execute(coinIDs: trendingCoinIDs)
+                .map(TrendingCoinItem.init)
         } catch {
             // TODO: Handle errors
         }

--- a/CryptoPrices/Sources/Home/Sources/Home/MyCoinsSectionView/MyCoinItem.swift
+++ b/CryptoPrices/Sources/Home/Sources/Home/MyCoinsSectionView/MyCoinItem.swift
@@ -5,6 +5,7 @@
 //  Created by Doan Thieu on 14/12/2022.
 //
 
+import DomainTestHelpers
 import Entities
 import Foundation
 
@@ -17,24 +18,6 @@ public struct MyCoinItem: Identifiable, Equatable {
     public let currentPrice: Decimal
     public let priceChangePercentage: Double
     public let isPriceUp: Bool
-
-    init(
-        id: String,
-        symbol: String,
-        name: String,
-        iconUrl: URL,
-        currentPrice: Decimal,
-        priceChangePercentage: Double,
-        isPriceUp: Bool
-    ) {
-        self.id = id
-        self.symbol = symbol.uppercased()
-        self.name = name
-        self.iconUrl = iconUrl
-        self.currentPrice = currentPrice
-        self.priceChangePercentage = priceChangePercentage
-        self.isPriceUp = isPriceUp
-   }
 
     public init(coin: Coin) {
         self.id = coin.id
@@ -50,15 +33,6 @@ public struct MyCoinItem: Identifiable, Equatable {
 #if DEBUG
 extension MyCoinItem {
 
-    // swiftlint:disable force_unwrapping
-    static let mock = MyCoinItem(
-        id: "bitcoin",
-        symbol: "btc",
-        name: "Bitcoin",
-        iconUrl: URL(string: "https://assets.coingecko.com/coins/images/1/large/bitcoin.png?1547033579")!,
-        currentPrice: 17_279.09,
-        priceChangePercentage: 2.44,
-        isPriceUp: false
-    )
+    static let mock = MyCoinItem(coin: MockCoin.single)
 }
 #endif

--- a/CryptoPrices/Sources/Home/Sources/Home/TrendingCoinsSectionView/TrendingCoinItem.swift
+++ b/CryptoPrices/Sources/Home/Sources/Home/TrendingCoinsSectionView/TrendingCoinItem.swift
@@ -5,6 +5,7 @@
 //  Created by Minh Pham on 29/12/2022.
 //
 
+import DomainTestHelpers
 import Entities
 import Foundation
 
@@ -16,22 +17,6 @@ public struct TrendingCoinItem: Identifiable, Equatable {
     public let iconUrl: URL
     public let priceChangePercentage: Double
     public let isPriceUp: Bool
-    
-    init(
-        id: String,
-        symbol: String,
-        name: String,
-        iconUrl: URL,
-        priceChangePercentage: Double,
-        isPriceUp: Bool
-    ) {
-        self.id = id
-        self.symbol = symbol.uppercased()
-        self.name = name
-        self.iconUrl = iconUrl
-        self.priceChangePercentage = priceChangePercentage
-        self.isPriceUp = isPriceUp
-    }
     
     public init(coin: Coin) {
         id = coin.id
@@ -46,14 +31,6 @@ public struct TrendingCoinItem: Identifiable, Equatable {
 #if DEBUG
 extension TrendingCoinItem {
     
-    // swiftlint:disable force_unwrapping
-    static let mock = TrendingCoinItem(
-        id: "bitcoin",
-        symbol: "btc",
-        name: "Bitcoin",
-        iconUrl: URL(string: "https://assets.coingecko.com/coins/images/1/large/bitcoin.png?1547033579")!,
-        priceChangePercentage: 2.44,
-        isPriceUp: false
-    )
+    static let mock = TrendingCoinItem(coin: MockCoin.single)
 }
 #endif

--- a/CryptoPrices/Sources/Home/Sources/Home/TrendingCoinsSectionView/TrendingCoinItem.swift
+++ b/CryptoPrices/Sources/Home/Sources/Home/TrendingCoinsSectionView/TrendingCoinItem.swift
@@ -10,14 +10,14 @@ import Entities
 import Foundation
 
 public struct TrendingCoinItem: Identifiable, Equatable {
-    
+
     public let id: String
     public let symbol: String
     public let name: String
     public let iconUrl: URL
     public let priceChangePercentage: Double
     public let isPriceUp: Bool
-    
+
     public init(coin: Coin) {
         id = coin.id
         symbol = coin.symbol.uppercased()
@@ -30,7 +30,7 @@ public struct TrendingCoinItem: Identifiable, Equatable {
 
 #if DEBUG
 extension TrendingCoinItem {
-    
+
     static let mock = TrendingCoinItem(coin: MockCoin.single)
 }
 #endif

--- a/CryptoPrices/Sources/Home/Sources/Home/TrendingCoinsSectionView/TrendingCoinItem.swift
+++ b/CryptoPrices/Sources/Home/Sources/Home/TrendingCoinsSectionView/TrendingCoinItem.swift
@@ -1,0 +1,59 @@
+//
+//  TrendingCoinItem.swift
+//  Home
+//
+//  Created by Minh Pham on 29/12/2022.
+//
+
+import Entities
+import Foundation
+
+public struct TrendingCoinItem: Identifiable, Equatable {
+    
+    public let id: String
+    public let symbol: String
+    public let name: String
+    public let iconUrl: URL
+    public let priceChangePercentage: Double
+    public let isPriceUp: Bool
+    
+    init(
+        id: String,
+        symbol: String,
+        name: String,
+        iconUrl: URL,
+        priceChangePercentage: Double,
+        isPriceUp: Bool
+    ) {
+        self.id = id
+        self.symbol = symbol.uppercased()
+        self.name = name
+        self.iconUrl = iconUrl
+        self.priceChangePercentage = priceChangePercentage
+        self.isPriceUp = isPriceUp
+    }
+    
+    public init(coin: Coin) {
+        id = coin.id
+        symbol = coin.symbol.uppercased()
+        name = coin.name
+        iconUrl = coin.image
+        priceChangePercentage = coin.priceChangePercentage24H
+        isPriceUp = coin.priceChangePercentage24H > 0.0
+    }
+}
+
+#if DEBUG
+extension TrendingCoinItem {
+    
+    // swiftlint:disable force_unwrapping
+    static let mock = TrendingCoinItem(
+        id: "bitcoin",
+        symbol: "btc",
+        name: "Bitcoin",
+        iconUrl: URL(string: "https://assets.coingecko.com/coins/images/1/large/bitcoin.png?1547033579")!,
+        priceChangePercentage: 2.44,
+        isPriceUp: false
+    )
+}
+#endif

--- a/CryptoPrices/Sources/Home/Sources/Home/TrendingCoinsSectionView/TrendingCoinItemView.swift
+++ b/CryptoPrices/Sources/Home/Sources/Home/TrendingCoinsSectionView/TrendingCoinItemView.swift
@@ -9,9 +9,6 @@ import SwiftUI
 
 struct TrendingCoinItemView: View {
 
-    // TODO: - Remove dummy
-    var percentage = 6.21
-
     var body: some View {
         HStack {
             HStack {
@@ -26,44 +23,57 @@ struct TrendingCoinItemView: View {
         .background(Colors.bgCurrencyItem.swiftUIColor)
         .cornerRadius(12.0)
     }
+
+    private let coinItem: TrendingCoinItem
+
+    init(_ coinItem: TrendingCoinItem) {
+        self.coinItem = coinItem
+    }
 }
 
 private extension TrendingCoinItemView {
 
     var coinImage: some View {
-        // TODO: - Remove dummy
-        Images.icBitcoin.swiftUIImage
-            .frame(width: 40.0, height: 40.0)
-            .clipShape(Circle())
+        AsyncImage(
+            url: coinItem.iconUrl,
+            content: { image in
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+            },
+            placeholder: {
+                // TODO: Update with proper placeholder or apply skeleton.
+                EmptyView()
+            }
+        )
+        .frame(width: 40.0, height: 40.0)
     }
 
     var coinInfo: some View {
-        // TODO: - Remove dummy
         VStack(alignment: .leading) {
-            Text("BTC")
+            Text(coinItem.symbol)
                 .foregroundColor(Colors.textBold.swiftUIColor)
                 .font(Fonts.Inter.semiBold.textStyle(.body))
                 .padding(.bottom, 4.0)
 
-            Text("Bitcoin")
+            Text(coinItem.name)
                 .foregroundColor(Colors.textMedium.swiftUIColor)
                 .font(Fonts.Inter.medium.textStyle(.callout))
         }
     }
 
     var priceChangePercentage: some View {
-        // TODO: - Remove dummy
         HStack {
-            percentage < 0.0
-            ? Images.icArrowDownRed.swiftUIImage
-            : Images.icArrowUpGreen.swiftUIImage
+            coinItem.isPriceUp
+            ? Images.icArrowUpGreen.swiftUIImage
+            : Images.icArrowDownRed.swiftUIImage
 
-            Text(percentage, format: .percentage)
+            Text(coinItem.priceChangePercentage, format: .percentage)
                 .font(Fonts.Inter.medium.textStyle(.body))
                 .foregroundColor(
-                    percentage < 0.0
-                    ? Colors.carnation.swiftUIColor
-                    : Colors.guppieGreen.swiftUIColor
+                    coinItem.isPriceUp
+                    ? Colors.guppieGreen.swiftUIColor
+                    : Colors.carnation.swiftUIColor
                 )
         }
     }
@@ -74,7 +84,7 @@ struct TrendingCoinItemView_Previews: PreviewProvider {
 
     static var previews: some View {
         Preview {
-            TrendingCoinItemView()
+            TrendingCoinItemView(.mock)
         }
     }
 }

--- a/CryptoPrices/Sources/Home/Sources/Home/TrendingCoinsSectionView/TrendingCoinSection.swift
+++ b/CryptoPrices/Sources/Home/Sources/Home/TrendingCoinsSectionView/TrendingCoinSection.swift
@@ -26,21 +26,25 @@ struct TrendingCoinSection: View {
             }
             .padding(16.0)
 
-            // TODO: - Remove dummy
             ScrollView(.vertical, showsIndicators: false) {
                 VStack {
-                    ForEach(0..<2) { _ in
-                        TrendingCoinItemView()
+                    ForEach(coins) { coin in
+                        TrendingCoinItemView(coin)
                             .padding(.vertical, 8.0)
                             .onTapGesture {
-                                // TODO: Remove hard-coded data
-                                homeState.didSelectCoin = "bitcoin"
+                                homeState.didSelectCoin = coin.id
                             }
                     }
                 }
                 .padding(.horizontal, 16.0)
             }
         }
+    }
+
+    private let coins: [TrendingCoinItem]
+
+    init(coins: [TrendingCoinItem]) {
+        self.coins = coins
     }
 }
 
@@ -49,7 +53,7 @@ struct TrendingCoinSection_Previews: PreviewProvider {
 
     static var previews: some View {
         Preview {
-            TrendingCoinSection()
+            MyCoinSection(coins: Array(repeating: .mock, count: 10))
         }
     }
 }

--- a/CryptoPrices/Sources/Home/Sources/Home/WalletStatisticSectionView/WalletStatisticSection.swift
+++ b/CryptoPrices/Sources/Home/Sources/Home/WalletStatisticSectionView/WalletStatisticSection.swift
@@ -1,5 +1,5 @@
 //
-//  WalletStatisticSection..swift
+//  WalletStatisticSection.swift
 //  Home
 //
 //  Created by Minh Pham on 07/12/2022.

--- a/CryptoPrices/Sources/Home/Tests/HomeTests/HomeViewModelSpec.swift
+++ b/CryptoPrices/Sources/Home/Tests/HomeTests/HomeViewModelSpec.swift
@@ -40,6 +40,13 @@ final class HomeViewModelSpec: QuickSpec {
                     }
                     .to(beEmpty())
                 }
+
+                it("has the correct value for trendingCoins") {
+                    await expect {
+                        await homeViewModel.trendingCoins
+                    }
+                    .to(beEmpty())
+                }
             }
 
             describe("its fetchMyCoins() call") {

--- a/CryptoPrices/Sources/Home/Tests/HomeTests/HomeViewModelSpec.swift
+++ b/CryptoPrices/Sources/Home/Tests/HomeTests/HomeViewModelSpec.swift
@@ -1,4 +1,11 @@
-// swiftlint:disable function_body_length closure_body_length superfluous_disable_command
+//
+//  HomeViewModelSpec.swift
+//  Home
+//
+//  Created by Mike Pham on 12/30/2022.
+//
+// swiftlint:disable function_body_length closure_body_length
+
 import DomainTestHelpers
 import Nimble
 import Quick
@@ -9,16 +16,24 @@ import UseCaseProtocol
 final class HomeViewModelSpec: QuickSpec {
 
     override func spec() {
+
         var homeViewModel: HomeViewModel!
         var myCoinsUseCase: MockMyCoinsUseCaseProtocol!
+        var trendingCoinsUseCase: MockTrendingCoinsUseCaseProtocol!
 
         describe("the HomeViewModel") {
+
             beforeEach {
                 myCoinsUseCase = MockMyCoinsUseCaseProtocol()
-                homeViewModel = await HomeViewModel(myCoinsUseCase: myCoinsUseCase)
+                trendingCoinsUseCase = MockTrendingCoinsUseCaseProtocol()
+                homeViewModel = await HomeViewModel(
+                    myCoinsUseCase: myCoinsUseCase,
+                    trendingCoinsUseCase: trendingCoinsUseCase
+                )
             }
 
             describe("its initial state") {
+
                 it("has the correct value for myCoins") {
                     await expect {
                         await homeViewModel.myCoins
@@ -28,7 +43,9 @@ final class HomeViewModelSpec: QuickSpec {
             }
 
             describe("its fetchMyCoins() call") {
+
                 context("when myCoinsUseCase returns success") {
+
                     let myCoinsReturnValue = [MockCoin.single]
                     let expectedCoins = [MyCoinItem(coin: MockCoin.single)]
 
@@ -38,14 +55,13 @@ final class HomeViewModelSpec: QuickSpec {
                     }
 
                     it("gets the correct value for myCoins") {
-                        await expect {
-                            await homeViewModel.myCoins
-                        }
-                        .to(equal(expectedCoins))
+                        await expect { await homeViewModel.myCoins }
+                            .to(equal(expectedCoins))
                     }
                 }
 
                 context("when myCoinsUseCase returns failure") {
+
                     let expectedError = TestError.fail("API error")
 
                     beforeEach {
@@ -56,6 +72,42 @@ final class HomeViewModelSpec: QuickSpec {
                     it("gets the correct value for myCoins") {
                         await expect {
                             await homeViewModel.myCoins
+                        }
+                        .to(beEmpty())
+                    }
+                }
+            }
+
+            describe("its fetchTrendingCoins() call") {
+
+                context("when trendingCoinsUseCase returns success") {
+
+                    let trendingCoinsReturnValue = [MockCoin.single]
+                    let expectedCoins = [TrendingCoinItem(coin: MockCoin.single)]
+
+                    beforeEach {
+                        trendingCoinsUseCase.executeCoinIDsReturnValue = trendingCoinsReturnValue
+                        await homeViewModel.fetchTrendingCoins()
+                    }
+
+                    it("gets the correct value for trendingCoins") {
+                        await expect { await homeViewModel.trendingCoins }
+                            .to(equal(expectedCoins))
+                    }
+                }
+
+                context("when trendingCoinsUseCase returns failure") {
+
+                    let expectedError = TestError.fail("API error")
+
+                    beforeEach {
+                        trendingCoinsUseCase.executeCoinIDsThrowableError = expectedError
+                        await homeViewModel.fetchTrendingCoins()
+                    }
+
+                    it("gets the correct value for trendingCoins") {
+                        await expect {
+                            await homeViewModel.trendingCoins
                         }
                         .to(beEmpty())
                     }


### PR DESCRIPTION
- Close #8

## What happened 👀

- Populate `TrendingCoinSection` with real data and removed all the hard-coded values.
- Update the coin route for trendingCoins API to `url`.
- Add missing metadata for the `HomeViewModelSpec` file.
- Setup the DI for the `TrendingCoinsUseCase` to work with the `HomeViewModel`.
- Add a new logic check to hide the `TrendingCoinSection` completely when there is no available data.
- Write unit tests for the new logic in the `HomeViewModel`.

## Insight 📝

Right now, in case there is no network, the section will only show the header part without any indication that the section is loading, and it will get even more annoying when the application is used with a poor network connection. 
<img src="https://user-images.githubusercontent.com/70877098/210034742-d3708930-dcdb-4dd9-9fa7-917226c21569.jpeg" width="300">
-> Therefore, a new logic to hide the section completely when there is no data is added to handle such a problem 🙏

## Proof Of Work 📹

- The Trending Coins section is now populated with real data from the server:

https://user-images.githubusercontent.com/70877098/210032251-8a569135-2428-4185-8100-95abf3d66fd5.MP4

- All new tests passed:
![Screenshot 2022-12-30 at 10 37 52](https://user-images.githubusercontent.com/70877098/210032079-4504d69a-ce87-485c-a83a-50649d714abc.png)


