### PR TITLE
[#11] [Integrate] As a user, when selecting a coin on the Home screen, I can see the coin’s header information on the Detail screen

### DIFF
--- a/CryptoPrices/Sources/App/AppView/AppCoordinator.swift
+++ b/CryptoPrices/Sources/App/AppView/AppCoordinator.swift
@@ -19,7 +19,7 @@ final class AppCoordinator: ObservableObject {
         let myCoinStatePublisher = $homeState
             .flatMap(\.$didSelectCoin)
             .compactMap { $0 }
-            .map { _ in Just(MyCoinState()) }
+            .map { Just(MyCoinState(id: $0)) }
             .assertNoFailure()
             .switchToLatest()
             .share()

--- a/CryptoPrices/Sources/App/AppView/AppView.swift
+++ b/CryptoPrices/Sources/App/AppView/AppView.swift
@@ -14,6 +14,7 @@ struct AppView: View {
 
     @StateObject private var appCoordinator: AppCoordinator = .init()
     @Injected(Container.homeViewModel) private var homeViewModel
+    @Injected(Container.myCoinViewModel) private var myCoinViewModel
     @State private var showingMyCoin = false
 
     var body: some View {
@@ -23,7 +24,7 @@ struct AppView: View {
                     .environmentObject(appCoordinator.homeState)
                 NavigationLink("", isActive: $showingMyCoin) {
                     if let myCoinState = appCoordinator.myCoinState {
-                        MyCoinView()
+                        MyCoinView(viewModel: myCoinViewModel)
                             .environmentObject(myCoinState)
                     }
                 }

--- a/CryptoPrices/Sources/App/DependenciesInjection/Container+Injection.swift
+++ b/CryptoPrices/Sources/App/DependenciesInjection/Container+Injection.swift
@@ -29,6 +29,14 @@ extension Container {
             trendingCoinsUseCase: trendingCoinsUseCase.callAsFunction()
         )
     }
+    static let myCoinViewModel = Factory {
+        MyCoinViewModel(
+            coinDetailUseCase:
+                CoinDetailUseCase(
+                    repository: coinRepository.callAsFunction()
+                )
+        )
+    }
 
     // Repositories
     static let coinRepository = Factory<CoinRepositoryProtocol> {
@@ -41,5 +49,8 @@ extension Container {
     }
     static let trendingCoinsUseCase = Factory<TrendingCoinsUseCaseProtocol> {
         TrendingCoinsUseCase(repository: coinRepository.callAsFunction())
+    }
+    static let coinDetailUseCase = Factory<CoinDetailUseCaseProtocol> {
+        CoinDetailUseCase(repository: coinRepository.callAsFunction())
     }
 }

--- a/CryptoPrices/Sources/App/DependenciesInjection/Container+Injection.swift
+++ b/CryptoPrices/Sources/App/DependenciesInjection/Container+Injection.swift
@@ -31,10 +31,7 @@ extension Container {
     }
     static let myCoinViewModel = Factory {
         MyCoinViewModel(
-            coinDetailUseCase:
-                CoinDetailUseCase(
-                    repository: coinRepository.callAsFunction()
-                )
+            coinDetailUseCase: coinDetailUseCase.callAsFunction()
         )
     }
 

--- a/CryptoPrices/Sources/MyCoin/Package.swift
+++ b/CryptoPrices/Sources/MyCoin/Package.swift
@@ -13,6 +13,8 @@ let package = Package(
         )
     ],
     dependencies: [
+        .package(name: "Domain", path: "../Domain"),
+        .package(name: "TestHelpers", path: "../TestHelpers"),
         .package(name: "Styleguide", path: "../Styleguide"),
         .package(url: "https://github.com/Quick/Quick", from: "6.1.0"),
         .package(url: "https://github.com/Quick/Nimble", from: "11.2.1")
@@ -20,12 +22,19 @@ let package = Package(
     targets: [
         .target(
             name: "MyCoin",
-            dependencies: [.product(name: "Styleguide", package: "Styleguide")]
+            dependencies: [
+                .product(name: "Styleguide", package: "Styleguide"),
+                .product(name: "UseCaseProtocol", package: "Domain"),
+                .product(name: "DomainTestHelpers", package: "Domain")
+            ]
         ),
         .testTarget(
             name: "MyCoinTests",
             dependencies: [
                 "MyCoin",
+                .product(name: "UseCaseProtocol", package: "Domain"),
+                .product(name: "DomainTestHelpers", package: "Domain"),
+                .product(name: "TestHelpers", package: "TestHelpers"),
                 .product(name: "Quick", package: "Quick"),
                 .product(name: "Nimble", package: "Nimble")
             ]

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/CoinDetailItem.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/CoinDetailItem.swift
@@ -1,0 +1,50 @@
+//
+//  CoinDetailItem.swift
+//  MyCoin
+//
+//  Created by Khanh on 02/01/2023.
+//
+
+import DomainTestHelpers
+import Entities
+import Foundation
+
+public struct CoinDetailItem: Identifiable, Equatable {
+
+    public let id: String
+    public let symbol: String
+    public let name: String
+    public let imageURL: URL
+    public let currentPrice: Decimal
+    public let priceChangePercentage24H: Double
+    public let marketCap: Decimal
+    public let marketCapChangePercentage24H: Double
+    public let ath: Decimal
+    public let athChangePercentage: Double
+    public let atl: Decimal
+    public let atlChangePercentage: Double
+
+    // swiftlint:disable force_unwrapping
+    public init(coinDetail: CoinDetail) {
+        let marketData = coinDetail.marketData
+        self.id = coinDetail.id
+        self.symbol = coinDetail.symbol.uppercased()
+        self.name = coinDetail.name
+        self.currentPrice = marketData.currentPrice.usd
+        self.imageURL = URL(string: coinDetail.image.large)!
+        self.priceChangePercentage24H = marketData.priceChangePercentage24H
+        self.marketCap = marketData.marketCap.usd
+        self.marketCapChangePercentage24H = marketData.marketCapChangePercentage24H
+        self.ath = marketData.ath.usd
+        self.athChangePercentage = marketData.athChangePercentage.usd
+        self.atl = marketData.atl.usd
+        self.atlChangePercentage = marketData.atlChangePercentage.usd
+    }
+}
+
+#if DEBUG
+extension CoinDetailItem {
+
+    static let mock = CoinDetailItem(coinDetail: MockCoinDetail.single)
+}
+#endif

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/CoinDetailItem.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/CoinDetailItem.swift
@@ -9,12 +9,12 @@ import DomainTestHelpers
 import Entities
 import Foundation
 
-public struct CoinDetailItem: Identifiable, Equatable {
+public struct CoinDetailItem: Equatable {
 
     public let id: String
     public let symbol: String
     public let name: String
-    public let imageURL: URL
+    public let imageURL: URL?
     public let currentPrice: Decimal
     public let priceChangePercentage24H: Double
     public let marketCap: Decimal
@@ -24,14 +24,13 @@ public struct CoinDetailItem: Identifiable, Equatable {
     public let atl: Decimal
     public let atlChangePercentage: Double
 
-    // swiftlint:disable force_unwrapping
     public init(coinDetail: CoinDetail) {
         let marketData = coinDetail.marketData
         self.id = coinDetail.id
         self.symbol = coinDetail.symbol.uppercased()
         self.name = coinDetail.name
         self.currentPrice = marketData.currentPrice.usd
-        self.imageURL = URL(string: coinDetail.image.large)!
+        self.imageURL = URL(string: coinDetail.image.large)
         self.priceChangePercentage24H = marketData.priceChangePercentage24H
         self.marketCap = marketData.marketCap.usd
         self.marketCapChangePercentage24H = marketData.marketCapChangePercentage24H

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinState.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinState.swift
@@ -8,7 +8,10 @@ import Combine
 
 public final class MyCoinState: ObservableObject {
 
+    @Published public var id: String = ""
     @Published public var didSelectBack = false
 
-    public init() {}
+    public init(id: String) {
+        self.id = id
+    }
 }

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
@@ -6,7 +6,6 @@
 
 import Styleguide
 import SwiftUI
-import UseCaseProtocol
 
 public struct MyCoinView: View {
 
@@ -65,6 +64,7 @@ private extension MyCoinView {
 
 #if DEBUG
 import DomainTestHelpers
+import UseCaseProtocol
 
 struct MyCoinView_Previews: PreviewProvider {
 

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
@@ -6,6 +6,7 @@
 
 import Styleguide
 import SwiftUI
+import UseCaseProtocol
 
 public struct MyCoinView: View {
 
@@ -15,7 +16,7 @@ public struct MyCoinView: View {
         contentView
             .navigationBarBackButtonHidden()
             .navigationBarItems(leading: backButton, trailing: likeButton)
-            .navigationTitle("Ethereum") // TODO: Remove dummy
+            .navigationTitle(viewModel.coinDetail?.name ?? "")
             .navigationBarTitleDisplayMode(.inline)
             .gesture(
                 DragGesture()
@@ -26,9 +27,16 @@ public struct MyCoinView: View {
                         }
                     }
             )
+            .task {
+                await viewModel.fetchCoinDetail(id: myCoinState.id)
+            }
     }
 
-    public init() {}
+    @ObservedObject private var viewModel: MyCoinViewModel
+
+    public init(viewModel: MyCoinViewModel) {
+        self.viewModel = viewModel
+    }
 }
 
 private extension MyCoinView {
@@ -56,11 +64,17 @@ private extension MyCoinView {
 }
 
 #if DEBUG
+import DomainTestHelpers
+
 struct MyCoinView_Previews: PreviewProvider {
 
     static var previews: some View {
         Preview {
-            MyCoinView()
+            MyCoinView(
+                viewModel: MyCoinViewModel(
+                    coinDetailUseCase: MockCoinDetailUseCaseProtocol()
+                )
+            )
         }
     }
 }

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinViewModel.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinViewModel.swift
@@ -1,0 +1,28 @@
+//
+//  MyCoinViewModel.swift
+//  MyCoin
+//
+//  Created by Khanh on 02/01/2023.
+//
+
+import Foundation
+import UseCaseProtocol
+
+@MainActor public final class MyCoinViewModel: ObservableObject {
+
+    private let coinDetailUseCase: CoinDetailUseCaseProtocol
+
+    @Published public private(set) var coinDetail: CoinDetailItem?
+
+    public init(coinDetailUseCase: CoinDetailUseCaseProtocol) {
+        self.coinDetailUseCase = coinDetailUseCase
+    }
+
+    public func fetchCoinDetail(id: String) async {
+        do {
+            coinDetail = try await CoinDetailItem(coinDetail: coinDetailUseCase.execute(id: id))
+        } catch {
+            // TODO: Handle errors
+        }
+    }
+}

--- a/CryptoPrices/Sources/MyCoin/Tests/MyCoinTests/MyCoinTests.swift
+++ b/CryptoPrices/Sources/MyCoin/Tests/MyCoinTests/MyCoinTests.swift
@@ -1,2 +1,0 @@
-import Nimble
-import Quick

--- a/CryptoPrices/Sources/MyCoin/Tests/MyCoinTests/MyCoinViewModelSpec.swift
+++ b/CryptoPrices/Sources/MyCoin/Tests/MyCoinTests/MyCoinViewModelSpec.swift
@@ -1,0 +1,79 @@
+//
+//  MyCoinViewModelSpec.swift
+//  MyCoin
+//
+//  Created by Khanh on 01/02/2023.
+//
+// swiftlint:disable closure_body_length
+
+import DomainTestHelpers
+import Nimble
+import Quick
+import TestHelpers
+import UseCaseProtocol
+@testable import MyCoin
+
+final class MyCoinViewModelSpec: QuickSpec {
+
+    override func spec() {
+
+        var myCoinViewModel: MyCoinViewModel!
+        var coinDetailUseCase: MockCoinDetailUseCaseProtocol!
+
+        describe("the MyCoinViewModel") {
+
+            beforeEach {
+                coinDetailUseCase = MockCoinDetailUseCaseProtocol()
+                myCoinViewModel = await MyCoinViewModel(
+                    coinDetailUseCase: coinDetailUseCase
+                )
+            }
+
+            describe("its initial state") {
+
+                it("has the correct value for coinDetail") {
+                    await expect {
+                        await myCoinViewModel.coinDetail
+                    }
+                    .to(beNil())
+                }
+            }
+
+            describe("its fetchCoinDetail() call") {
+
+                context("when coinDetailUseCase returns success") {
+
+                    let coinDetailReturnValue = MockCoinDetail.single
+                    let expectedCoins = CoinDetailItem(coinDetail: MockCoinDetail.single)
+
+                    beforeEach {
+                        coinDetailUseCase.executeIdReturnValue = coinDetailReturnValue
+                        await myCoinViewModel.fetchCoinDetail(id: "bitcoin")
+                    }
+
+                    it("gets the correct value for coinDetail") {
+                        await expect { await myCoinViewModel.coinDetail }
+                            .to(equal(expectedCoins))
+                    }
+                }
+
+                context("when coinDetailUseCase returns failure") {
+
+                    let expectedError = TestError.fail("API error")
+
+                    beforeEach {
+                        coinDetailUseCase.executeIdThrowableError = expectedError
+                        await myCoinViewModel.fetchCoinDetail(id: "bitcoin")
+                    }
+
+                    it("gets the correct value for coinDetail") {
+                        await expect {
+                            await myCoinViewModel.coinDetail
+                        }
+                        .to(beNil())
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Close #11

## What happened 👀

- Implemented `MyCoinViewModel`.
- Created `CoinDetailItem`.
- Added Unit tests for `MyCoinViewModelSpec`.

## Insight 📝
- N/A

## Proof Of Work 📹

https://user-images.githubusercontent.com/25881847/210262652-ba44d3f9-08c0-4efb-8256-8cdd2b9d764c.mp4


