### PR TITLE
[#59] [Chore] Use Swift package plugin to support swiftgen generate code for resources - part 2

### DIFF
--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
@@ -4,6 +4,7 @@
 //  Created by Mike Pham on 04/12/2022.
 //
 
+import DomainTestHelpers
 import Styleguide
 import SwiftUI
 

--- a/fastlane/Helpers/Build.swift
+++ b/fastlane/Helpers/Build.swift
@@ -51,6 +51,7 @@ enum Build {
             ]),
             buildPath: .userDefined(Constant.buildPath),
             derivedDataPath: .userDefined(Constant.derivedDataPath),
+            xcargs: .userDefined("-skipPackagePluginValidation"),
             xcodebuildFormatter: "xcbeautify",
             clonedSourcePackagesPath: .userDefined(Constant.clonedSourcePackagesPath)
         )


### PR DESCRIPTION
- Close #59

## What happened 👀

We did set the `-skipPackagePluginValidation` flag when building and testing with `fastlane` in the PR #80.
This PR did the same when building and archiving (to deploy to Firebase)

## Insight 📝

`N/A`

## Proof Of Work 📹

`N/A`
