### PR TITLE
[#46] [UI] As a user, I can see the Buy & Sell buttons on the Detail screen

### DIFF
--- a/CryptoPrices/Sources/Home/Sources/Home/HomeView/HomeView.swift
+++ b/CryptoPrices/Sources/Home/Sources/Home/HomeView/HomeView.swift
@@ -8,7 +8,7 @@ import UseCaseProtocol
 import Styleguide
 import SwiftUI
 
-typealias Section = Styleguide.Section
+private typealias Section = Styleguide.Section
 
 public struct HomeView: View {
 

--- a/CryptoPrices/Sources/Home/Sources/Home/HomeView/HomeView.swift
+++ b/CryptoPrices/Sources/Home/Sources/Home/HomeView/HomeView.swift
@@ -8,6 +8,8 @@ import UseCaseProtocol
 import Styleguide
 import SwiftUI
 
+typealias Section = Styleguide.Section
+
 public struct HomeView: View {
 
     public var body: some View {

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/CoinStatisticsSection/CoinStatisticsSection.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/CoinStatisticsSection/CoinStatisticsSection.swift
@@ -77,7 +77,6 @@ private extension CoinStatisticsSection {
                     : Colors.carnation.swiftUIColor
                 )
         }
-        .padding(.bottom, 24.0)
     }
 }
 

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
@@ -8,28 +8,39 @@ import DomainTestHelpers
 import Styleguide
 import SwiftUI
 
+typealias Section = Styleguide.Section
+
 public struct MyCoinView: View {
 
     @EnvironmentObject var myCoinState: MyCoinState
 
     public var body: some View {
-        contentView
-            .navigationBarBackButtonHidden()
-            .navigationBarItems(leading: backButton, trailing: likeButton)
-            .navigationTitle(viewModel.coinDetail?.name ?? "")
-            .navigationBarTitleDisplayMode(.inline)
-            .gesture(
-                DragGesture()
-                    .onEnded { value in
-                        // Handle swipe left-to-right
-                        if value.startLocation.x < 20.0 && value.translation.width > 50.0 {
-                            myCoinState.didSelectBack = true
-                        }
+        List {
+            currentPriceSection
+            priceChartSection
+            coinStatisticsSection
+        }
+        .listStyle(.plain)
+        .background(Colors.bgMain.swiftUIColor)
+        .navigationBarBackButtonHidden()
+        .navigationBarItems(leading: backButton, trailing: likeButton)
+        .navigationTitle(viewModel.coinDetail?.name ?? "")
+        .navigationBarTitleDisplayMode(.inline)
+        .gesture(
+            DragGesture()
+                .onEnded { value in
+                    // Handle swipe left-to-right
+                    if value.startLocation.x < 20.0 && value.translation.width > 50.0 {
+                        myCoinState.didSelectBack = true
                     }
-            )
-            .task {
-                await viewModel.fetchCoinDetail(id: myCoinState.id)
-            }
+                }
+        )
+        .safeAreaInset(edge: .bottom, content: {
+            footerView
+        })
+        .task {
+            await viewModel.fetchCoinDetail(id: myCoinState.id)
+        }
     }
 
     @ObservedObject private var viewModel: MyCoinViewModel
@@ -41,24 +52,29 @@ public struct MyCoinView: View {
 
 private extension MyCoinView {
 
-    var contentView: some View {
-        ScrollView {
+    var currentPriceSection: some View {
+        Section {
             CurrentPriceSection()
-            Spacer(minLength: 38.0)
+        }
+    }
+
+    var priceChartSection: some View {
+        Section {
             PriceLineChartSection()
                 .frame(height: 196.0)
-            // TODO: - Add time filter here
-            // TODO: - Remove dummy
+
             TimeFrameSection()
+        }
+    }
+
+    var coinStatisticsSection: some View {
+        Section {
             CoinStatisticsSection(
                 coinDetailItem: CoinDetailItem(
                     coinDetail: MockCoinDetail.single
                 )
             )
         }
-        .clipped(antialiased: false)
-        .frame(maxHeight: .infinity)
-        .background(Colors.bgMain.swiftUIColor)
     }
 
     var backButton: some View {
@@ -71,6 +87,31 @@ private extension MyCoinView {
 
     var likeButton: some View {
         Images.icHeart.swiftUIImage
+    }
+
+    var sellButton: some View {
+        Button(action: {}, label: {
+            Text(Strings.MyCoin.SellButton.title)
+                .frame(maxWidth: .infinity)
+        })
+        .buttonStyle(SecondaryButtonStyle())
+    }
+
+    var buyButton: some View {
+        Button(action: {}, label: {
+            Text(Strings.MyCoin.BuyButton.title)
+                .frame(maxWidth: .infinity)
+        })
+        .buttonStyle(PrimaryButtonStyle())
+    }
+
+    var footerView: some View {
+        HStack(alignment: .center, spacing: 24.0) {
+            sellButton
+            buyButton
+        }
+        .padding(16.0)
+        .background(Colors.bgMain.swiftUIColor)
     }
 }
 

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
@@ -8,7 +8,7 @@ import DomainTestHelpers
 import Styleguide
 import SwiftUI
 
-typealias Section = Styleguide.Section
+private typealias Section = Styleguide.Section
 
 public struct MyCoinView: View {
 

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/Resources/en.lproj/Localizable.strings
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/Resources/en.lproj/Localizable.strings
@@ -1,6 +1,8 @@
-"myCoin.marketCap.title" = "Market Cap";
 "myCoin.ath.title" = "All Time High";
 "myCoin.atl.title" = "All Time Low";
+"myCoin.buyButton.title" = "Buy";
+"myCoin.marketCap.title" = "Market Cap";
+"myCoin.sellButton.title" = "Sell";
 "myCoin.timeFrame.oneDayText" = "1D";
 "myCoin.timeFrame.oneWeekText" = "1W";
 "myCoin.timeFrame.oneMonthText" = "1M";

--- a/CryptoPrices/Sources/Styleguide/Sources/Styleguide/ButtonStyles/PrimaryButtonStyle.swift
+++ b/CryptoPrices/Sources/Styleguide/Sources/Styleguide/ButtonStyles/PrimaryButtonStyle.swift
@@ -1,0 +1,28 @@
+//
+//  PrimaryButtonStyle.swift
+//  Styleguide
+//
+//  Created by Doan Thieu on 10/01/2023.
+//
+
+import SwiftUI
+
+public struct PrimaryButtonStyle: ButtonStyle {
+
+    private static let backgroundColor = Colors.guppieGreen.swiftUIColor
+    private static let selectedBackgroundColor = Colors.guppieGreen.swiftUIColor.opacity(0.5)
+
+    public init() {}
+
+    public func makeBody(configuration: Configuration) -> some View {
+        configuration
+            .label
+            .font(Fonts.Inter.medium.textStyle(.body))
+            .frame(height: 48.0)
+            .background(
+                configuration.isPressed ? Self.selectedBackgroundColor : Self.backgroundColor
+            )
+            .cornerRadius(12.0)
+            .foregroundColor(.white)
+    }
+}

--- a/CryptoPrices/Sources/Styleguide/Sources/Styleguide/ButtonStyles/SecondaryButtonStyle.swift
+++ b/CryptoPrices/Sources/Styleguide/Sources/Styleguide/ButtonStyles/SecondaryButtonStyle.swift
@@ -1,0 +1,28 @@
+//
+//  SecondaryButtonStyle.swift
+//  Styleguide
+//
+//  Created by Doan Thieu on 10/01/2023.
+//
+
+import SwiftUI
+
+public struct SecondaryButtonStyle: ButtonStyle {
+
+    private static let backgroundColor = Colors.carnation.swiftUIColor
+    private static let selectedBackgroundColor = Colors.carnation.swiftUIColor.opacity(0.5)
+
+    public init() {}
+
+    public func makeBody(configuration: Configuration) -> some View {
+        configuration
+            .label
+            .font(Fonts.Inter.medium.textStyle(.body))
+            .frame(height: 48.0)
+            .background(
+                configuration.isPressed ? Self.selectedBackgroundColor : Self.backgroundColor
+            )
+            .cornerRadius(12.0)
+            .foregroundColor(.white)
+    }
+}

--- a/CryptoPrices/Sources/Styleguide/Sources/Styleguide/CommonViews/Section.swift
+++ b/CryptoPrices/Sources/Styleguide/Sources/Styleguide/CommonViews/Section.swift
@@ -6,25 +6,24 @@
 //  Created by Doan Thieu on 06/01/2023.
 //
 
-import Styleguide
 import SwiftUI
 
-struct Section<Content, Header>: View where Content: View, Header: View {
+public struct Section<Content, Header>: View where Content: View, Header: View {
 
     private let content: Content
     private let header: Header?
 
-    init(@ViewBuilder content: () -> Content) where Header == EmptyView {
+    public init(@ViewBuilder content: () -> Content) where Header == EmptyView {
         self.content = content()
         self.header = nil
     }
 
-    init(@ViewBuilder content: () -> Content, @ViewBuilder header: () -> Header) {
+    public init(@ViewBuilder content: () -> Content, @ViewBuilder header: () -> Header) {
         self.content = content()
         self.header = header()
     }
 
-    var body: some View {
+    public var body: some View {
         VStack(spacing: 0.0) {
             header
             content


### PR DESCRIPTION
- Close #46

## What happened 👀

- Refactor `MyCoinView`
  - Replace `ScrollView` with `List` (this is also necessary when we implement the [pull-to-refresh](https://github.com/nimblehq/nimble-crypto-ios/issues/63) later)
  - Move `Section` into `Styleguide` and make it public so it can be used by `HomeView` and `MyCoinView`
- Create 2 button styles `PrimaryButtonStyle` and `SecondaryButtonStyle`, applied for __Buy__ and __Sell__ buttons respectively for the `MyCoinView`

## Insight 📝

When it comes to styling the `Button` (or any SwiftUI views in general), there's more than one way. I once talked about it in our chapter retro, and had some examples of that in our [swiftui-showcases](https://github.com/nimblehq/swiftui-showcases/pull/8/files#diff-f0a542b787c9bd27040c2eb02ce2e61d2cc09e78e341e17fafc33a3201032b0e). But IMHO use the `buttonStyle` seems the most idiomatic one 🙏 

## Proof Of Work 📹

|iPhone 14 - Dark Mode|iPhone SE - Light Mode|
|---|---|
|<video src="https://user-images.githubusercontent.com/17972674/211490356-3b826ac3-318d-4b0e-b5d1-aeee721cf4e9.mp4">|<video src="https://user-images.githubusercontent.com/17972674/211491023-94671c48-51e4-48a8-91c7-f60ea16b0194.mp4">|
