### PR TITLE
[#45] [Integrate] As a user, I can see the coin’s statistics on the Detail screen

### DIFF
--- a/CryptoPrices/Sources/Domain/Sources/DomainTestHelpers/Mocks/MockCoinDetail/MockCoinDetail.swift
+++ b/CryptoPrices/Sources/Domain/Sources/DomainTestHelpers/Mocks/MockCoinDetail/MockCoinDetail.swift
@@ -16,7 +16,8 @@ public struct MockCoinDetail: CoinDetail, Equatable {
     public let marketData: MarketData
 
     public static func == (lhs: MockCoinDetail, rhs: MockCoinDetail) -> Bool {
-        lhs.id == rhs.id
+        lhs.id == rhs.id &&
+        MockMarketData(marketData: lhs.marketData) == MockMarketData(marketData: rhs.marketData)
     }
 }
 

--- a/CryptoPrices/Sources/Domain/Sources/DomainTestHelpers/Mocks/MockCoinDetail/MockMarketData.swift
+++ b/CryptoPrices/Sources/Domain/Sources/DomainTestHelpers/Mocks/MockCoinDetail/MockMarketData.swift
@@ -17,8 +17,46 @@ public struct MockMarketData: MarketData, Equatable {
     public let athChangePercentage: USDDoublable
     public let atl: USDDecimalable
     public let atlChangePercentage: USDDoublable
-    
+
+    public init(marketData: MarketData) {
+        self.currentPrice = marketData.currentPrice
+        self.priceChangePercentage24H = marketData.priceChangePercentage24H
+        self.marketCap = marketData.marketCap
+        self.marketCapChangePercentage24H = marketData.marketCapChangePercentage24H
+        self.ath = marketData.ath
+        self.athChangePercentage = marketData.athChangePercentage
+        self.atl = marketData.atl
+        self.atlChangePercentage = marketData.atlChangePercentage
+    }
+
+    public init(
+        currentPrice: USDDecimalable,
+        priceChangePercentage24H: Double,
+        marketCap: USDDecimalable,
+        marketCapChangePercentage24H: Double,
+        ath: USDDecimalable,
+        athChangePercentage: USDDoublable,
+        atl: USDDecimalable,
+        atlChangePercentage: USDDoublable
+    ) {
+        self.currentPrice = currentPrice
+        self.priceChangePercentage24H = priceChangePercentage24H
+        self.marketCap = marketCap
+        self.marketCapChangePercentage24H = marketCapChangePercentage24H
+        self.ath = ath
+        self.athChangePercentage = athChangePercentage
+        self.atl = atl
+        self.atlChangePercentage = atlChangePercentage
+    }
+
     public static func == (lhs: MockMarketData, rhs: MockMarketData) -> Bool {
-        lhs.currentPrice.usd == rhs.currentPrice.usd
+        lhs.currentPrice.usd == rhs.currentPrice.usd &&
+        lhs.priceChangePercentage24H == rhs.priceChangePercentage24H &&
+        lhs.marketCap.usd == rhs.marketCap.usd &&
+        lhs.marketCapChangePercentage24H == rhs.marketCapChangePercentage24H &&
+        lhs.ath.usd == rhs.ath.usd &&
+        lhs.athChangePercentage.usd == rhs.athChangePercentage.usd &&
+        lhs.atl.usd == rhs.atl.usd &&
+        lhs.atlChangePercentage.usd == rhs.atlChangePercentage.usd
     }
 }

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/CoinStatisticsSection/CoinStatisticsSection.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/CoinStatisticsSection/CoinStatisticsSection.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Khanh on 03/01/2023.
 //
+// swiftlint:disable void_function_in_ternary
 
 import Styleguide
 import SwiftUI
@@ -14,30 +15,37 @@ struct CoinStatisticsSection: View {
         VStack {
             coinStatisticsItemView(
                 title: Strings.MyCoin.MarketCap.title,
-                price: coinDetailItem?.marketCap,
-                isPriceUp: coinDetailItem?.isMarketCapChangePercentage24HUp ?? false,
-                percentage: coinDetailItem?.marketCapChangePercentage24H
+                price: coinDetailItem.marketCap,
+                isPriceUp: coinDetailItem.isMarketCapChangePercentage24HUp,
+                percentage: coinDetailItem.marketCapChangePercentage24H
             )
+            .padding(.bottom, 24.0)
             coinStatisticsItemView(
                 title: Strings.MyCoin.Ath.title,
-                price: coinDetailItem?.ath,
-                isPriceUp: coinDetailItem?.isAthChangePercentageUp ?? false,
-                percentage: coinDetailItem?.athChangePercentage
+                price: coinDetailItem.ath,
+                isPriceUp: coinDetailItem.isAthChangePercentageUp,
+                percentage: coinDetailItem.athChangePercentage
             )
+            .padding(.bottom, 24.0)
             coinStatisticsItemView(
                 title: Strings.MyCoin.Atl.title,
-                price: coinDetailItem?.atl,
-                isPriceUp: coinDetailItem?.isAtlChangePercentageUp ?? false,
-                percentage: coinDetailItem?.atlChangePercentage
+                price: coinDetailItem.atl,
+                isPriceUp: coinDetailItem.isAtlChangePercentageUp,
+                percentage: coinDetailItem.atlChangePercentage
             )
         }
         .padding(16.0)
     }
 
-    private let coinDetailItem: CoinDetailItem?
+    private let coinDetailItem: CoinDetailItem
+    private let showData: Bool
 
-    init(coinDetailItem: CoinDetailItem?) {
+    init(
+        coinDetailItem: CoinDetailItem,
+        showData: Bool
+    ) {
         self.coinDetailItem = coinDetailItem
+        self.showData = showData
     }
 }
 
@@ -45,37 +53,39 @@ private extension CoinStatisticsSection {
 
     func coinStatisticsItemView(
         title: String,
-        price: Decimal?,
+        price: Decimal,
         isPriceUp: Bool,
-        percentage: Double?
+        percentage: Double
     ) -> some View {
         HStack {
             VStack(
                 alignment: .leading,
-                spacing: 16.0
+                spacing: 10.0
             ) {
                 Text(title)
                     .foregroundColor(Colors.textMedium.swiftUIColor)
                     .font(Fonts.Inter.medium.textStyle(.caption))
 
-                if let price {
+                ZStack(alignment: .leading) {
                     Text(price, format: .dollarCurrency)
                         .foregroundColor(Colors.titleMedium.swiftUIColor)
                         .font(Fonts.Inter.medium.textStyle(.callout))
-                } else {
+                        .opacity(showData ? 1.0 : 0.0)
+                    
                     Text(Strings.MyCoin.NoData.text)
                         .foregroundColor(Colors.titleMedium.swiftUIColor)
                         .font(Fonts.Inter.medium.textStyle(.callout))
+                        .opacity(showData ? 0.0 : 1.0)
                 }
             }
 
             Spacer()
 
-            if let percentage {
-                isPriceUp
-                ? Images.icArrowUpGreen.swiftUIImage
-                : Images.icArrowDownRed.swiftUIImage
-                
+            isPriceUp
+            ? Images.icArrowUpGreen.swiftUIImage.opacity(showData ? 1.0 : 0.0)
+            : Images.icArrowDownRed.swiftUIImage.opacity(showData ? 1.0 : 0.0)
+
+            ZStack(alignment: .trailing) {
                 Text(percentage, format: .percentage)
                     .font(Fonts.Inter.medium.textStyle(.body))
                     .foregroundColor(
@@ -83,9 +93,11 @@ private extension CoinStatisticsSection {
                         ? Colors.guppieGreen.swiftUIColor
                         : Colors.carnation.swiftUIColor
                     )
-            } else {
+                    .opacity(showData ? 1.0 : 0.0)
+                
                 Text(Strings.MyCoin.NoData.text)
                     .font(Fonts.Inter.medium.textStyle(.body))
+                    .opacity(showData ? 0.0 : 1.0)
             }
         }
     }
@@ -101,7 +113,8 @@ struct CoinStatisticsSection_Previews: PreviewProvider {
             CoinStatisticsSection(
                 coinDetailItem: CoinDetailItem(
                     coinDetail: MockCoinDetail.single
-                )
+                ),
+                showData: true
             )
         }
     }

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/CoinStatisticsSection/CoinStatisticsSection.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/CoinStatisticsSection/CoinStatisticsSection.swift
@@ -4,7 +4,6 @@
 //
 //  Created by Khanh on 03/01/2023.
 //
-// swiftlint:disable void_function_in_ternary
 
 import Styleguide
 import SwiftUI
@@ -38,14 +37,14 @@ struct CoinStatisticsSection: View {
     }
 
     private let coinDetailItem: CoinDetailItem
-    private let showData: Bool
+    private let shouldShowData: Bool
 
     init(
         coinDetailItem: CoinDetailItem,
-        showData: Bool
+        shouldShowData: Bool
     ) {
         self.coinDetailItem = coinDetailItem
-        self.showData = showData
+        self.shouldShowData = shouldShowData
     }
 }
 
@@ -70,20 +69,22 @@ private extension CoinStatisticsSection {
                     Text(price, format: .dollarCurrency)
                         .foregroundColor(Colors.titleMedium.swiftUIColor)
                         .font(Fonts.Inter.medium.textStyle(.callout))
-                        .opacity(showData ? 1.0 : 0.0)
+                        .opacity(shouldShowData ? 1.0 : 0.0)
                     
                     Text(Strings.MyCoin.NoData.text)
                         .foregroundColor(Colors.titleMedium.swiftUIColor)
                         .font(Fonts.Inter.medium.textStyle(.callout))
-                        .opacity(showData ? 0.0 : 1.0)
+                        .opacity(shouldShowData ? 0.0 : 1.0)
                 }
             }
 
             Spacer()
 
-            isPriceUp
-            ? Images.icArrowUpGreen.swiftUIImage.opacity(showData ? 1.0 : 0.0)
-            : Images.icArrowDownRed.swiftUIImage.opacity(showData ? 1.0 : 0.0)
+            if isPriceUp {
+                Images.icArrowUpGreen.swiftUIImage
+            } else {
+                Images.icArrowDownRed.swiftUIImage
+            }
 
             ZStack(alignment: .trailing) {
                 Text(percentage, format: .percentage)
@@ -93,11 +94,11 @@ private extension CoinStatisticsSection {
                         ? Colors.guppieGreen.swiftUIColor
                         : Colors.carnation.swiftUIColor
                     )
-                    .opacity(showData ? 1.0 : 0.0)
-                
+                    .opacity(shouldShowData ? 1.0 : 0.0)
+
                 Text(Strings.MyCoin.NoData.text)
                     .font(Fonts.Inter.medium.textStyle(.body))
-                    .opacity(showData ? 0.0 : 1.0)
+                    .opacity(shouldShowData ? 0.0 : 1.0)
             }
         }
     }
@@ -114,7 +115,7 @@ struct CoinStatisticsSection_Previews: PreviewProvider {
                 coinDetailItem: CoinDetailItem(
                     coinDetail: MockCoinDetail.single
                 ),
-                showData: true
+                shouldShowData: true
             )
         }
     }

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/CoinStatisticsSection/CoinStatisticsSection.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/CoinStatisticsSection/CoinStatisticsSection.swift
@@ -14,29 +14,29 @@ struct CoinStatisticsSection: View {
         VStack {
             coinStatisticsItemView(
                 title: Strings.MyCoin.MarketCap.title,
-                price: coinDetailItem.marketCap,
-                isPriceUp: coinDetailItem.isMarketCapChangePercentage24HUp,
-                percentage: coinDetailItem.marketCapChangePercentage24H
+                price: coinDetailItem?.marketCap,
+                isPriceUp: coinDetailItem?.isMarketCapChangePercentage24HUp ?? false,
+                percentage: coinDetailItem?.marketCapChangePercentage24H
             )
             coinStatisticsItemView(
                 title: Strings.MyCoin.Ath.title,
-                price: coinDetailItem.ath,
-                isPriceUp: coinDetailItem.isAthChangePercentageUp,
-                percentage: coinDetailItem.athChangePercentage
+                price: coinDetailItem?.ath,
+                isPriceUp: coinDetailItem?.isAthChangePercentageUp ?? false,
+                percentage: coinDetailItem?.athChangePercentage
             )
             coinStatisticsItemView(
                 title: Strings.MyCoin.Atl.title,
-                price: coinDetailItem.atl,
-                isPriceUp: coinDetailItem.isAtlChangePercentageUp,
-                percentage: coinDetailItem.atlChangePercentage
+                price: coinDetailItem?.atl,
+                isPriceUp: coinDetailItem?.isAtlChangePercentageUp ?? false,
+                percentage: coinDetailItem?.atlChangePercentage
             )
         }
         .padding(16.0)
     }
 
-    private let coinDetailItem: CoinDetailItem
+    private let coinDetailItem: CoinDetailItem?
 
-    init(coinDetailItem: CoinDetailItem) {
+    init(coinDetailItem: CoinDetailItem?) {
         self.coinDetailItem = coinDetailItem
     }
 }
@@ -45,9 +45,9 @@ private extension CoinStatisticsSection {
 
     func coinStatisticsItemView(
         title: String,
-        price: Decimal,
+        price: Decimal?,
         isPriceUp: Bool,
-        percentage: Double
+        percentage: Double?
     ) -> some View {
         HStack {
             VStack(
@@ -58,24 +58,35 @@ private extension CoinStatisticsSection {
                     .foregroundColor(Colors.textMedium.swiftUIColor)
                     .font(Fonts.Inter.medium.textStyle(.caption))
 
-                Text(price, format: .dollarCurrency)
-                    .foregroundColor(Colors.titleMedium.swiftUIColor)
-                    .font(Fonts.Inter.medium.textStyle(.callout))
+                if let price {
+                    Text(price, format: .dollarCurrency)
+                        .foregroundColor(Colors.titleMedium.swiftUIColor)
+                        .font(Fonts.Inter.medium.textStyle(.callout))
+                } else {
+                    Text(Strings.MyCoin.NoData.text)
+                        .foregroundColor(Colors.titleMedium.swiftUIColor)
+                        .font(Fonts.Inter.medium.textStyle(.callout))
+                }
             }
 
             Spacer()
 
-            isPriceUp
-            ? Images.icArrowUpGreen.swiftUIImage
-            : Images.icArrowDownRed.swiftUIImage
-
-            Text(percentage, format: .percentage)
-                .font(Fonts.Inter.medium.textStyle(.body))
-                .foregroundColor(
-                    isPriceUp
-                    ? Colors.guppieGreen.swiftUIColor
-                    : Colors.carnation.swiftUIColor
-                )
+            if let percentage {
+                isPriceUp
+                ? Images.icArrowUpGreen.swiftUIImage
+                : Images.icArrowDownRed.swiftUIImage
+                
+                Text(percentage, format: .percentage)
+                    .font(Fonts.Inter.medium.textStyle(.body))
+                    .foregroundColor(
+                        isPriceUp
+                        ? Colors.guppieGreen.swiftUIColor
+                        : Colors.carnation.swiftUIColor
+                    )
+            } else {
+                Text(Strings.MyCoin.NoData.text)
+                    .font(Fonts.Inter.medium.textStyle(.body))
+            }
         }
     }
 }

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
@@ -70,7 +70,8 @@ private extension MyCoinView {
     var coinStatisticsSection: some View {
         Section {
             CoinStatisticsSection(
-                coinDetailItem: viewModel.coinDetail
+                coinDetailItem: viewModel.coinDetail ?? CoinDetailItem(coinDetail: MockCoinDetail.single),
+                showData: viewModel.coinDetail != nil
             )
         }
     }

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
@@ -70,9 +70,7 @@ private extension MyCoinView {
     var coinStatisticsSection: some View {
         Section {
             CoinStatisticsSection(
-                coinDetailItem: viewModel.coinDetail ?? CoinDetailItem(
-                    coinDetail: MockCoinDetail.single
-                )
+                coinDetailItem: viewModel.coinDetail
             )
         }
     }

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
@@ -70,7 +70,7 @@ private extension MyCoinView {
     var coinStatisticsSection: some View {
         Section {
             CoinStatisticsSection(
-                coinDetailItem: CoinDetailItem(
+                coinDetailItem: viewModel.coinDetail ?? CoinDetailItem(
                     coinDetail: MockCoinDetail.single
                 )
             )

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
@@ -71,7 +71,7 @@ private extension MyCoinView {
         Section {
             CoinStatisticsSection(
                 coinDetailItem: viewModel.coinDetail ?? CoinDetailItem(coinDetail: MockCoinDetail.single),
-                showData: viewModel.coinDetail != nil
+                shouldShowData: viewModel.coinDetail != nil
             )
         }
     }

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/Resources/en.lproj/Localizable.strings
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/Resources/en.lproj/Localizable.strings
@@ -2,6 +2,7 @@
 "myCoin.atl.title" = "All Time Low";
 "myCoin.buyButton.title" = "Buy";
 "myCoin.marketCap.title" = "Market Cap";
+"myCoin.noData.text" = "-";
 "myCoin.sellButton.title" = "Sell";
 "myCoin.timeFrame.oneDayText" = "1D";
 "myCoin.timeFrame.oneWeekText" = "1W";

--- a/CryptoPrices/Sources/MyCoin/Tests/MyCoinTests/MyCoinViewModelSpec.swift
+++ b/CryptoPrices/Sources/MyCoin/Tests/MyCoinTests/MyCoinViewModelSpec.swift
@@ -50,7 +50,7 @@ final class MyCoinViewModelSpec: QuickSpec {
                 context("when coinDetailUseCase returns success") {
 
                     let coinDetailReturnValue = MockCoinDetail.single
-                    let expectedCoins = CoinDetailItem(coinDetail: MockCoinDetail.single)
+                    let expectedCoin = CoinDetailItem(coinDetail: MockCoinDetail.single)
 
                     beforeEach {
                         coinDetailUseCase.executeIdReturnValue = coinDetailReturnValue
@@ -59,7 +59,7 @@ final class MyCoinViewModelSpec: QuickSpec {
 
                     it("gets the correct value for coinDetail") {
                         await expect { await myCoinViewModel.coinDetail }
-                            .to(equal(expectedCoins))
+                            .to(equal(expectedCoin))
                     }
                 }
 


### PR DESCRIPTION
- Close #45

## What happened 👀

- Passing data from `viewModel.coinDetail` to `CoinStatisticsSection`.
- Configure `Equatable` function of `MockCoinDetail` and `MockMarketData`.
- Add new initializers for `MockMarketData`.

## Insight 📝

- We tested the correct value for `coinDetail`, and market cap, all time high, all time low values are coinDetail's properties, so we don't need to write tests for checking market cap, all time high, all time low.

```swift
                    it("gets the correct value for coinDetail") {
                        await expect { await myCoinViewModel.coinDetail }
                            .to(equal(expectedCoins))
                    }
```

## Proof Of Work 📹

https://user-images.githubusercontent.com/25881847/211710974-0ef8d62b-4fd7-40b9-bcb3-4ac93284b622.mp4


