### PR TITLE
[#14] [Integrate] As a user, I can see the coin’s current price on the Detail screen

### DIFF
--- a/CryptoPrices/Sources/Home/Sources/Home/MyCoinsView/MyCoinItem.swift
+++ b/CryptoPrices/Sources/Home/Sources/Home/MyCoinsView/MyCoinItem.swift
@@ -17,7 +17,6 @@ public struct MyCoinItem: Identifiable, Equatable {
     public let iconUrl: URL
     public let currentPrice: Decimal
     public let priceChangePercentage: Double
-    public let isPriceUp: Bool
 
     public init(coin: Coin) {
         self.id = coin.id
@@ -26,7 +25,6 @@ public struct MyCoinItem: Identifiable, Equatable {
         self.iconUrl = coin.image
         self.currentPrice = coin.currentPrice
         self.priceChangePercentage = coin.priceChangePercentage24H
-        self.isPriceUp = coin.priceChangePercentage24H > 0.0
     }
 }
 

--- a/CryptoPrices/Sources/Home/Sources/Home/MyCoinsView/MyCoinItemView.swift
+++ b/CryptoPrices/Sources/Home/Sources/Home/MyCoinsView/MyCoinItemView.swift
@@ -77,19 +77,8 @@ private extension MyCoinItemView {
     }
     
     var priceChangePercentage: some View {
-        HStack {
-            coinItem.isPriceUp
-            ? Images.icArrowUpGreen.swiftUIImage
-            : Images.icArrowDownRed.swiftUIImage
-
-            Text(coinItem.priceChangePercentage, format: .percentage)
-                .font(Fonts.Inter.medium.textStyle(.body))
-                .foregroundColor(
-                    coinItem.isPriceUp
-                    ? Colors.guppieGreen.swiftUIColor
-                    : Colors.carnation.swiftUIColor
-                )
-        }
+        PercentageView(coinItem.priceChangePercentage)
+            .font(Fonts.Inter.medium.textStyle(.body))
     }
 }
 

--- a/CryptoPrices/Sources/Home/Sources/Home/TrendingCoinsView/TrendingCoinItem.swift
+++ b/CryptoPrices/Sources/Home/Sources/Home/TrendingCoinsView/TrendingCoinItem.swift
@@ -16,7 +16,6 @@ public struct TrendingCoinItem: Identifiable, Equatable {
     public let name: String
     public let iconUrl: URL
     public let priceChangePercentage: Double
-    public let isPriceUp: Bool
 
     public init(coin: Coin) {
         id = coin.id
@@ -24,7 +23,6 @@ public struct TrendingCoinItem: Identifiable, Equatable {
         name = coin.name
         iconUrl = coin.image
         priceChangePercentage = coin.priceChangePercentage24H
-        isPriceUp = coin.priceChangePercentage24H > 0.0
     }
 }
 

--- a/CryptoPrices/Sources/Home/Sources/Home/TrendingCoinsView/TrendingCoinItemView.swift
+++ b/CryptoPrices/Sources/Home/Sources/Home/TrendingCoinsView/TrendingCoinItemView.swift
@@ -63,19 +63,8 @@ private extension TrendingCoinItemView {
     }
 
     var priceChangePercentage: some View {
-        HStack {
-            coinItem.isPriceUp
-            ? Images.icArrowUpGreen.swiftUIImage
-            : Images.icArrowDownRed.swiftUIImage
-
-            Text(coinItem.priceChangePercentage, format: .percentage)
-                .font(Fonts.Inter.medium.textStyle(.body))
-                .foregroundColor(
-                    coinItem.isPriceUp
-                    ? Colors.guppieGreen.swiftUIColor
-                    : Colors.carnation.swiftUIColor
-                )
-        }
+        PercentageView(coinItem.priceChangePercentage)
+            .font(Fonts.Inter.medium.textStyle(.body))
     }
 }
 

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/CoinStatisticsSection/CoinStatisticsSection.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/CoinStatisticsSection/CoinStatisticsSection.swift
@@ -15,21 +15,20 @@ struct CoinStatisticsSection: View {
             coinStatisticsItemView(
                 title: Strings.MyCoin.MarketCap.title,
                 price: coinDetailItem.marketCap,
-                isPriceUp: coinDetailItem.isMarketCapChangePercentage24HUp,
                 percentage: coinDetailItem.marketCapChangePercentage24H
             )
             .padding(.bottom, 24.0)
+
             coinStatisticsItemView(
                 title: Strings.MyCoin.Ath.title,
                 price: coinDetailItem.ath,
-                isPriceUp: coinDetailItem.isAthChangePercentageUp,
                 percentage: coinDetailItem.athChangePercentage
             )
             .padding(.bottom, 24.0)
+
             coinStatisticsItemView(
                 title: Strings.MyCoin.Atl.title,
                 price: coinDetailItem.atl,
-                isPriceUp: coinDetailItem.isAtlChangePercentageUp,
                 percentage: coinDetailItem.atlChangePercentage
             )
         }
@@ -53,7 +52,6 @@ private extension CoinStatisticsSection {
     func coinStatisticsItemView(
         title: String,
         price: Decimal,
-        isPriceUp: Bool,
         percentage: Double
     ) -> some View {
         HStack {
@@ -80,26 +78,9 @@ private extension CoinStatisticsSection {
 
             Spacer()
 
-            if isPriceUp {
-                Images.icArrowUpGreen.swiftUIImage
-            } else {
-                Images.icArrowDownRed.swiftUIImage
-            }
-
-            ZStack(alignment: .trailing) {
-                Text(percentage, format: .percentage)
-                    .font(Fonts.Inter.medium.textStyle(.body))
-                    .foregroundColor(
-                        isPriceUp
-                        ? Colors.guppieGreen.swiftUIColor
-                        : Colors.carnation.swiftUIColor
-                    )
-                    .opacity(shouldShowData ? 1.0 : 0.0)
-
-                Text(Strings.MyCoin.NoData.text)
-                    .font(Fonts.Inter.medium.textStyle(.body))
-                    .opacity(shouldShowData ? 0.0 : 1.0)
-            }
+            PercentageView(percentage)
+                .font(Fonts.Inter.medium.textStyle(.body))
+                .opacity(shouldShowData ? 1.0 : 0.0)
         }
     }
 }

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/CurrentPriceSectionView/CurrentPriceSection.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/CurrentPriceSectionView/CurrentPriceSection.swift
@@ -33,17 +33,8 @@ struct CurrentPriceSection: View {
 
                 Button(action: {}, label: {
                     HStack {
-                        coinItem.isPriceChangePercentage24HUp
-                        ? Images.icArrowUpGreen.swiftUIImage
-                        : Images.icArrowDownRed.swiftUIImage
-
-                        Text(coinItem.priceChangePercentage24H, format: .percentage)
+                        PercentageView(coinItem.priceChangePercentage24H)
                             .font(Fonts.Inter.medium.textStyle(.callout))
-                            .foregroundColor(
-                                coinItem.isPriceChangePercentage24HUp
-                                ? Colors.guppieGreen.swiftUIColor
-                                : Colors.carnation.swiftUIColor
-                            )
                     }
                 })
                 .padding(EdgeInsets(top: 8.0, leading: 10.0, bottom: 8.0, trailing: 10.0))

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/CurrentPriceSectionView/CurrentPriceSection.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/CurrentPriceSectionView/CurrentPriceSection.swift
@@ -12,27 +12,38 @@ struct CurrentPriceSection: View {
 
     var body: some View {
         VStack(spacing: 8.0) {
-            // TODO: - Remove dummy
-            Images.icEth.swiftUIImage
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 60.0, height: 60.0)
-                .clipShape(Circle())
+            AsyncImage(
+                url: coinItem.imageURL,
+                content: { image in
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                },
+                placeholder: {
+                    EmptyView()
+                }
+            )
+            .frame(width: 60.0, height: 60.0)
 
             VStack(spacing: 4.0) {
-                // TODO: Remove hard-coded data
-                Text(7_273_291, format: .dollarCurrency)
+                Text(coinItem.currentPrice, format: .dollarCurrency)
                     .foregroundColor(Colors.textBold.swiftUIColor)
                     .font(Fonts.Inter.semiBold.textStyle(.title))
                     .frame(height: 34.0)
 
                 Button(action: {}, label: {
                     HStack {
-                        Images.icArrowUpGreen.swiftUIImage
-                        // TODO: Remove hard-coded data
-                        Text(2.41, format: .percentage)
+                        coinItem.isPriceChangePercentage24HUp
+                        ? Images.icArrowUpGreen.swiftUIImage
+                        : Images.icArrowDownRed.swiftUIImage
+
+                        Text(coinItem.priceChangePercentage24H, format: .percentage)
                             .font(Fonts.Inter.medium.textStyle(.callout))
-                        
+                            .foregroundColor(
+                                coinItem.isPriceChangePercentage24HUp
+                                ? Colors.guppieGreen.swiftUIColor
+                                : Colors.carnation.swiftUIColor
+                            )
                     }
                 })
                 .padding(EdgeInsets(top: 8.0, leading: 10.0, bottom: 8.0, trailing: 10.0))
@@ -44,6 +55,12 @@ struct CurrentPriceSection: View {
         .padding(.vertical, 8.0)
         .frame(maxWidth: .infinity)
     }
+
+    private let coinItem: CoinDetailItem
+
+    init(_ coinItem: CoinDetailItem) {
+        self.coinItem = coinItem
+    }
 }
 
 #if DEBUG
@@ -51,7 +68,7 @@ struct CurrentPriceSection_Previews: PreviewProvider {
 
     static var previews: some View {
         Preview {
-            CurrentPriceSection()
+            CurrentPriceSection(.mock)
         }
     }
 }

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/CoinDetailItem.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/CoinDetailItem.swift
@@ -23,10 +23,6 @@ public struct CoinDetailItem: Equatable {
     public let athChangePercentage: Double
     public let atl: Decimal
     public let atlChangePercentage: Double
-    public let isPriceChangePercentage24HUp: Bool
-    public let isMarketCapChangePercentage24HUp: Bool
-    public let isAthChangePercentageUp: Bool
-    public let isAtlChangePercentageUp: Bool
 
     public init(coinDetail: CoinDetail) {
         let marketData = coinDetail.marketData
@@ -42,10 +38,6 @@ public struct CoinDetailItem: Equatable {
         self.athChangePercentage = marketData.athChangePercentage.usd
         self.atl = marketData.atl.usd
         self.atlChangePercentage = marketData.atlChangePercentage.usd
-        self.isPriceChangePercentage24HUp = marketData.priceChangePercentage24H > 0.0
-        self.isMarketCapChangePercentage24HUp = marketData.marketCapChangePercentage24H > 0.0
-        self.isAthChangePercentageUp = marketData.athChangePercentage.usd > 0.0
-        self.isAtlChangePercentageUp = marketData.atlChangePercentage.usd > 0.0
     }
 }
 

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
@@ -4,7 +4,6 @@
 //  Created by Mike Pham on 04/12/2022.
 //
 
-import DomainTestHelpers
 import Styleguide
 import SwiftUI
 
@@ -60,8 +59,10 @@ public struct MyCoinView: View {
 private extension MyCoinView {
 
     var currentPriceSection: some View {
-        Section {
-            CurrentPriceSection()
+        viewModel.coinDetail.map { coinDetail in
+            Section {
+                CurrentPriceSection(coinDetail)
+            }
         }
     }
 

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
@@ -4,6 +4,7 @@
 //  Created by Mike Pham on 04/12/2022.
 //
 
+import DomainTestHelpers
 import Styleguide
 import SwiftUI
 

--- a/CryptoPrices/Sources/Styleguide/Sources/Styleguide/CommonViews/PercentageView.swift
+++ b/CryptoPrices/Sources/Styleguide/Sources/Styleguide/CommonViews/PercentageView.swift
@@ -1,0 +1,32 @@
+//
+//  PercentageView.swift
+//  Styleguide
+//
+//  Created by Doan Thieu on 11/01/2023.
+//
+
+import SwiftUI
+
+public struct PercentageView: View {
+
+    private let value: Double
+
+    public var body: some View {
+        HStack {
+            value > 0.0
+            ? Images.icArrowUpGreen.swiftUIImage
+            : Images.icArrowDownRed.swiftUIImage
+
+            Text(value, format: .percentage)
+                .foregroundColor(
+                    value > 0.0
+                    ? Colors.guppieGreen.swiftUIColor
+                    : Colors.carnation.swiftUIColor
+                )
+        }
+    }
+
+    public init(_ value: Double) {
+        self.value = value
+    }
+}


### PR DESCRIPTION
- Close #14

## What happened 👀

- The UI of the percentage value and indicator ( <img width="80" alt="Screenshot 2023-01-13 at 09 51 51" src="https://user-images.githubusercontent.com/17972674/212226451-553eb238-2c8e-49f7-a9aa-43dd51b2394e.png"> and <img width="70" alt="Screenshot 2023-01-13 at 09 52 11" src="https://user-images.githubusercontent.com/17972674/212226459-d612edd8-687a-4840-8594-f3d53d54fc33.png"> ) appears quite frequently. So I extracted them into the `PercentageView` in the `Styleguide`. Then, because the logic to make styling (red or blue color,  up or down chevron) is now embedded in the `PercentageView`, this also effectively removes many predicate properties on the (UI) models e.g. `isPriceUp`, `isMarketCapChangePercentage24HUp`, `isAthChangePercentageUp`, etc, ...
- The `CurrentPriceSection` now uses the real data to display (by the given `CoinDetailItem` passed through the initializer)
- When there's no internet connection and the app doesn't get the actual data to display, I'd prefer to keep it as a blank view. This is easy to handle and can avoid conditional checks in SwiftUI views. And because it's a part of a larger view (`MyCoinView`), it still plays nice since other parts have already shown the indication of no data by `"No Data"` or `"-"`.

## Insight 📝

- Another candidate to be extracted into a common view is the Coin's icon, i.e the `AsyncImage(url:content:placeholder:)` but I couldn't decide which implementation I should go, i.e wrapping in a new `struct RemoteImage` view (easy), extend the `Image` with static function (easy) or extend the `AsyncImage` (complex because it generics over many types, including the private one). So I will leave it for later.
 
## Proof Of Work 📹

| Got the data from API | No Internet connection |
|---|---|
|<video src="https://user-images.githubusercontent.com/17972674/212586288-3f29a51c-1b71-40f2-b0b4-711c6ce07ada.mp4">|<video src="https://user-images.githubusercontent.com/17972674/212586297-2c743e2e-dc77-4de0-b471-42a6bb015ec2.mp4">|

