### PR TITLE
[#63] [Integrate] As a user, I can pull to refresh data on the Detail screen

### DIFF
--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
@@ -48,6 +48,9 @@ public struct MyCoinView: View {
                 await viewModel.fetchChartPricesData(id: myCoinState.id, timeFrameItem: selectedTimeFrameItem)
             }
         }
+        .refreshable {
+            await viewModel.fetchData(id: myCoinState.id, timeFrameItem: .init(timeFrame: .oneDay))
+        }
     }
 
     @ObservedObject private var viewModel: MyCoinViewModel

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
@@ -15,6 +15,7 @@ public struct MyCoinView: View {
     @EnvironmentObject var myCoinState: MyCoinState
 
     @State private var selectedTimeFrameItem: TimeFrameItem = .init(timeFrame: .oneDay)
+    @State private var tempSelectedTimeFrameItem: TimeFrameItem = .init(timeFrame: .oneDay)
 
     public var body: some View {
         List {
@@ -48,8 +49,16 @@ public struct MyCoinView: View {
                 await viewModel.fetchChartPricesData(id: myCoinState.id, timeFrameItem: selectedTimeFrameItem)
             }
         }
+        .onReceive(viewModel.$isSuccess) { isSuccess in
+            if isSuccess {
+                tempSelectedTimeFrameItem = selectedTimeFrameItem
+            } else {
+                selectedTimeFrameItem = tempSelectedTimeFrameItem
+            }
+        }
         .refreshable {
-            await viewModel.fetchData(id: myCoinState.id, timeFrameItem: .init(timeFrame: .oneDay))
+            selectedTimeFrameItem = .init(timeFrame: .oneDay)
+            await viewModel.fetchCoinDetail(id: myCoinState.id)
         }
     }
 

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinViewModel.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinViewModel.swift
@@ -15,6 +15,7 @@ import UseCaseProtocol
 
     @Published public private(set) var coinDetail: CoinDetailItem?
     @Published public private(set) var chartData: [ChartDataPointUIModel] = []
+    @Published public private(set) var isSuccess = false
 
     public init(
         coinDetailUseCase: CoinDetailUseCaseProtocol,
@@ -37,7 +38,9 @@ import UseCaseProtocol
         do {
             let dataPoints = try await getChartPricesUseCase.execute(coinID: id, filter: timeFrameItem.timeFrame)
             chartData = dataPoints.map { ChartDataPointUIModel(dataPoint: $0) }
+            isSuccess = true
         } catch {
+            isSuccess = false
             // TODO: Handle errors
         }
     }

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/TimeFrameSectionView/TimeFrameSection.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/TimeFrameSectionView/TimeFrameSection.swift
@@ -9,9 +9,9 @@ import Styleguide
 import SwiftUI
 
 struct TimeFrameSection: View {
-    
+
     @Binding var selected: TimeFrameItem
-    
+
     private let timeFrameList: [TimeFrameItem] = [
         .init(timeFrame: .oneDay),
         .init(timeFrame: .oneWeek),

--- a/CryptoPrices/Sources/MyCoin/Tests/MyCoinTests/MyCoinViewModelSpec.swift
+++ b/CryptoPrices/Sources/MyCoin/Tests/MyCoinTests/MyCoinViewModelSpec.swift
@@ -142,6 +142,11 @@ final class MyCoinViewModelSpec: QuickSpec {
                         await expect { await myCoinViewModel.chartData }
                             .to(equal(expectedChartData))
                     }
+
+                    it("returns chart data successfully") {
+                        await expect { await myCoinViewModel.isSuccess }
+                            .to(equal(true))
+                    }
                 }
 
                 context("when coinDetailUseCase returns success but getChartPricesUseCase returns failure") {
@@ -163,6 +168,11 @@ final class MyCoinViewModelSpec: QuickSpec {
                     it("returns empty chart data") {
                         await expect { await myCoinViewModel.chartData }
                             .to(equal([]))
+                    }
+
+                    it("returns chart data unsuccessfully") {
+                        await expect { await myCoinViewModel.isSuccess }
+                            .to(equal(false))
                     }
                 }
 
@@ -186,6 +196,11 @@ final class MyCoinViewModelSpec: QuickSpec {
                         await expect { await myCoinViewModel.chartData }
                             .to(equal(expectedChartData))
                     }
+
+                    it("returns chart data successfully") {
+                        await expect { await myCoinViewModel.isSuccess }
+                            .to(equal(true))
+                    }
                 }
 
                 context("when coinDetailUseCase and getChartPricesUseCase both return failure") {
@@ -205,6 +220,11 @@ final class MyCoinViewModelSpec: QuickSpec {
                     it("returns empty chart data") {
                         await expect { await myCoinViewModel.chartData }
                             .to(equal([]))
+                    }
+
+                    it("returns chart data unsuccessfully") {
+                        await expect { await myCoinViewModel.isSuccess }
+                            .to(equal(false))
                     }
                 }
             }


### PR DESCRIPTION
- Close #63

## What happened 👀

- Add refreshable for calling all APIs when pulling to refresh.

## Insight 📝
- The loading indicator's put on the same as the design. Because when applying the `refreshable` modifier to the `List`, the loading indicator will place on the top of the `List` and below the navigation bar as the default.

## Proof Of Work 📹

https://user-images.githubusercontent.com/25881847/212016035-4bb1a52a-45e6-4782-b4e9-543bc6a6119e.mp4
