### PR TITLE
[#43] [Integrate] As a user, I can see timeframe bar on the Detail screen

### DIFF
--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
@@ -13,9 +13,10 @@ private typealias Section = Styleguide.Section
 public struct MyCoinView: View {
 
     @EnvironmentObject var myCoinState: MyCoinState
+    @State private var selectedTimeFrameItem: TimeFrameItem = .init(timeFrame: .oneDay)
 
     public var body: some View {
-        List {
+        ScrollView {
             currentPriceSection
             priceChartSection
             coinStatisticsSection
@@ -39,7 +40,12 @@ public struct MyCoinView: View {
             footerView
         })
         .task {
-            await viewModel.fetchData(id: myCoinState.id)
+            await viewModel.fetchData(id: myCoinState.id, timeFrameItem: selectedTimeFrameItem)
+        }
+        .onChange(of: selectedTimeFrameItem) { _ in
+            Task {
+                await viewModel.fetchData(id: myCoinState.id, timeFrameItem: selectedTimeFrameItem)
+            }
         }
     }
 
@@ -63,7 +69,7 @@ private extension MyCoinView {
             PriceLineChartSection(viewModel.chartData)
                 .frame(height: 196.0)
 
-            TimeFrameSection()
+            TimeFrameSection(selected: $selectedTimeFrameItem)
         }
     }
 

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
@@ -44,7 +44,7 @@ public struct MyCoinView: View {
         }
         .onChange(of: selectedTimeFrameItem) { _ in
             Task {
-                await viewModel.fetchData(id: myCoinState.id, timeFrameItem: selectedTimeFrameItem)
+                await viewModel.fetchChartPricesData(id: myCoinState.id, timeFrameItem: selectedTimeFrameItem)
             }
         }
     }

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
@@ -13,6 +13,7 @@ private typealias Section = Styleguide.Section
 public struct MyCoinView: View {
 
     @EnvironmentObject var myCoinState: MyCoinState
+
     @State private var selectedTimeFrameItem: TimeFrameItem = .init(timeFrame: .oneDay)
 
     public var body: some View {

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinView.swift
@@ -16,7 +16,7 @@ public struct MyCoinView: View {
     @State private var selectedTimeFrameItem: TimeFrameItem = .init(timeFrame: .oneDay)
 
     public var body: some View {
-        ScrollView {
+        List {
             currentPriceSection
             priceChartSection
             coinStatisticsSection

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinViewModel.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/MyCoinView/MyCoinViewModel.swift
@@ -33,20 +33,19 @@ import UseCaseProtocol
         }
     }
 
-    // TODO: Support different filters
-    public func fetchChartPricesData(id: String) async {
+    public func fetchChartPricesData(id: String, timeFrameItem: TimeFrameItem) async {
         do {
-            let dataPoints = try await getChartPricesUseCase.execute(coinID: id, filter: .oneDay)
+            let dataPoints = try await getChartPricesUseCase.execute(coinID: id, filter: timeFrameItem.timeFrame)
             chartData = dataPoints.map { ChartDataPointUIModel(dataPoint: $0) }
         } catch {
             // TODO: Handle errors
         }
     }
 
-    public func fetchData(id: String) async {
+    public func fetchData(id: String, timeFrameItem: TimeFrameItem) async {
         await withTaskGroup(of: Void.self) { taskGroup in
             taskGroup.addTask { await self.fetchCoinDetail(id: id) }
-            taskGroup.addTask { await self.fetchChartPricesData(id: id) }
+            taskGroup.addTask { await self.fetchChartPricesData(id: id, timeFrameItem: timeFrameItem) }
         }
     }
 }

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/TimeFrameSectionView/TimeFrameItem.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/TimeFrameSectionView/TimeFrameItem.swift
@@ -9,9 +9,8 @@ import DomainTestHelpers
 import Entities
 import Foundation
 
-public struct TimeFrameItem: Identifiable, Equatable {
+public struct TimeFrameItem: Equatable {
 
-    public let id = UUID()
     let timeFrame: TimeFilter
     var title: String {
         switch timeFrame {

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/TimeFrameSectionView/TimeFrameItem.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/TimeFrameSectionView/TimeFrameItem.swift
@@ -9,9 +9,9 @@ import DomainTestHelpers
 import Entities
 import Foundation
 
-struct TimeFrameItem: Identifiable, Equatable {
+public struct TimeFrameItem: Identifiable, Equatable {
 
-    let id = UUID()
+    public let id = UUID()
     let timeFrame: TimeFilter
     var title: String {
         switch timeFrame {
@@ -23,7 +23,7 @@ struct TimeFrameItem: Identifiable, Equatable {
         }
     }
 
-    static func == (lhs: TimeFrameItem, rhs: TimeFrameItem) -> Bool {
+    public static func == (lhs: TimeFrameItem, rhs: TimeFrameItem) -> Bool {
         lhs.timeFrame == rhs.timeFrame
     }
 }

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/TimeFrameSectionView/TimeFrameSection.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/TimeFrameSectionView/TimeFrameSection.swift
@@ -45,8 +45,17 @@ struct TimeFrameSection: View {
             .padding(.horizontal, 40.0)
             .padding(.vertical, 24.0)
         }
-        .onChange(of: selected) { newValue in
-            print(newValue)
+        .animation(.default, value: selected)
+    }
+}
+
+#if DEBUG
+struct TimeFrameSection_Previews: PreviewProvider {
+
+    static var previews: some View {
+        Preview {
+            TimeFrameSection(selected: .constant(.init(timeFrame: .oneDay)))
         }
     }
 }
+#endif

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/TimeFrameSectionView/TimeFrameSection.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/TimeFrameSectionView/TimeFrameSection.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct TimeFrameSection: View {
     
-    @State private var selected: TimeFrameItem = .init(timeFrame: .oneDay)
+    @Binding var selected: TimeFrameItem
     
     private let timeFrameList: [TimeFrameItem] = [
         .init(timeFrame: .oneDay),
@@ -25,7 +25,6 @@ struct TimeFrameSection: View {
             HStack {
                 ForEach(timeFrameList) { item in
                     Button(item.title) {
-                        // TODO: - handling loading chart logic
                         selected = TimeFrameItem(timeFrame: item.timeFrame)
                     }
                     .frame(width: 46.0, height: 32.0)
@@ -46,16 +45,8 @@ struct TimeFrameSection: View {
             .padding(.horizontal, 40.0)
             .padding(.vertical, 24.0)
         }
-    }
-}
-
-#if DEBUG
-struct TimeFrameSection_Previews: PreviewProvider {
-
-    static var previews: some View {
-        Preview {
-            TimeFrameSection()
+        .onChange(of: selected) { newValue in
+            print(newValue)
         }
     }
 }
-#endif

--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/TimeFrameSectionView/TimeFrameSection.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/TimeFrameSectionView/TimeFrameSection.swift
@@ -23,10 +23,11 @@ struct TimeFrameSection: View {
     var body: some View {
         VStack(alignment: .center) {
             HStack {
-                ForEach(timeFrameList) { item in
+                ForEach(timeFrameList, id: \.timeFrame) { item in
                     Button(item.title) {
                         selected = TimeFrameItem(timeFrame: item.timeFrame)
                     }
+                    .buttonStyle(.borderless)
                     .frame(width: 46.0, height: 32.0)
                     .foregroundColor(
                         selected == TimeFrameItem(timeFrame: item.timeFrame)

--- a/CryptoPrices/Sources/MyCoin/Tests/MyCoinTests/MyCoinViewModelSpec.swift
+++ b/CryptoPrices/Sources/MyCoin/Tests/MyCoinTests/MyCoinViewModelSpec.swift
@@ -88,7 +88,10 @@ final class MyCoinViewModelSpec: QuickSpec {
 
                     beforeEach {
                         getChartPricesUseCase.executeCoinIDFilterReturnValue = chartDataReturnValue
-                        await myCoinViewModel.fetchChartPricesData(id: "bitcoin")
+                        await myCoinViewModel.fetchChartPricesData(
+                            id: "bitcoin",
+                            timeFrameItem: .init(timeFrame: .oneWeek)
+                        )
                     }
 
                     it("gets the correct value for chartData") {
@@ -103,7 +106,10 @@ final class MyCoinViewModelSpec: QuickSpec {
 
                     beforeEach {
                         getChartPricesUseCase.executeCoinIDFilterThrowableError = expectedError
-                        await myCoinViewModel.fetchChartPricesData(id: "bitcoin")
+                        await myCoinViewModel.fetchChartPricesData(
+                            id: "bitcoin",
+                            timeFrameItem: .init(timeFrame: .oneDay)
+                        )
                     }
 
                     it("returns empty chart data") {
@@ -124,7 +130,7 @@ final class MyCoinViewModelSpec: QuickSpec {
                     beforeEach {
                         coinDetailUseCase.executeIdReturnValue = coinDetailReturnValue
                         getChartPricesUseCase.executeCoinIDFilterReturnValue = chartDataReturnValue
-                        await myCoinViewModel.fetchData(id: "bitcoin")
+                        await myCoinViewModel.fetchData(id: "bitcoin", timeFrameItem: .init(timeFrame: .oneDay))
                     }
 
                     it("gets the correct value for coinDetail") {
@@ -146,7 +152,7 @@ final class MyCoinViewModelSpec: QuickSpec {
                     beforeEach {
                         coinDetailUseCase.executeIdReturnValue = coinDetailReturnValue
                         getChartPricesUseCase.executeCoinIDFilterThrowableError = expectedError
-                        await myCoinViewModel.fetchData(id: "bitcoin")
+                        await myCoinViewModel.fetchData(id: "bitcoin", timeFrameItem: .init(timeFrame: .oneDay))
                     }
 
                     it("gets the correct value for coinDetail") {
@@ -168,7 +174,7 @@ final class MyCoinViewModelSpec: QuickSpec {
                     beforeEach {
                         coinDetailUseCase.executeIdThrowableError = expectedError
                         getChartPricesUseCase.executeCoinIDFilterReturnValue = chartDataReturnValue
-                        await myCoinViewModel.fetchData(id: "bitcoin")
+                        await myCoinViewModel.fetchData(id: "bitcoin", timeFrameItem: .init(timeFrame: .oneDay))
                     }
 
                     it("returns nil for coinDetail") {
@@ -188,7 +194,7 @@ final class MyCoinViewModelSpec: QuickSpec {
                     beforeEach {
                         coinDetailUseCase.executeIdThrowableError = expectedError
                         getChartPricesUseCase.executeCoinIDFilterThrowableError = expectedError
-                        await myCoinViewModel.fetchData(id: "bitcoin")
+                        await myCoinViewModel.fetchData(id: "bitcoin", timeFrameItem: .init(timeFrame: .oneDay))
                     }
 
                     it("returns nil for coinDetail") {


### PR DESCRIPTION
- Close #43

## What happened 👀

- Added filter parameter to `fetchChartPricesData` function to request data chart based on timeframe (1D, 1W, 1M, 1Y, 5Ys).
- Added animation for the timeframe bar.
- Updated Unit test in `MyCoinViewModelSpec`.

## Insight 📝

- Changed `List` to `ScrollView`, because when using `List`, we have a problem with the timeframe bar as the following:

https://user-images.githubusercontent.com/25881847/212232444-ee9de8c7-6fd0-4fa7-bdd9-062bd8e7f393.mp4

And for the concern of refreshing, I will handle it at [this PR](https://github.com/nimblehq/nimble-crypto-ios/pull/98).

- For [this suggestion](https://github.com/nimblehq/nimble-crypto-ios/pull/86#discussion_r1063071065) from anh Thieu, I tried to implement the timeframe bar with the approach of the built-in `Picker`, but it's not closed to the design. Therefore, I will skip this attempt and still keep this current implementation.
## Proof Of Work 📹

https://user-images.githubusercontent.com/25881847/212232594-8454a2f6-e051-4a6a-a954-b82a8c2a7cb3.mp4

