### PR TITLE
[#14] [Integrate] As a user, I can see the coin’s current price on the Detail screen - part 2

### DIFF
--- a/CryptoPrices/Sources/MyCoin/Sources/MyCoin/CurrentPriceSectionView/CurrentPriceSection.swift
+++ b/CryptoPrices/Sources/MyCoin/Sources/MyCoin/CurrentPriceSectionView/CurrentPriceSection.swift
@@ -39,7 +39,11 @@ struct CurrentPriceSection: View {
                 })
                 .padding(EdgeInsets(top: 8.0, leading: 10.0, bottom: 8.0, trailing: 10.0))
                 .foregroundColor(Colors.guppieGreen.swiftUIColor)
-                .background(Colors.scandal.swiftUIColor)
+                .background(
+                    coinItem.priceChangePercentage24H > 0.0
+                    ? Colors.scandal.swiftUIColor
+                    : Colors.carnation.swiftUIColor.opacity(0.3)
+                )
                 .cornerRadius(20.0)
             }
         }


### PR DESCRIPTION
- Close #14

## What happened 👀

The PRs #67 and #97 implemented the UI and Integration for the current price on the Detail screen. However, they missed styling the percentage value's background color when negative. This PR adds that part.

## Insight 📝
N/A

## Proof Of Work 📹

| Light mode | Dark mode |
|---|---|
|![Simulator Screen Shot - iPhone 14 - 2023-01-19 at 15 46 02](https://user-images.githubusercontent.com/17972674/213400578-885b5cf4-684d-4b20-b3ed-342155adf64d.png)|![Simulator Screen Shot - iPhone 14 - 2023-01-19 at 16 00 25](https://user-images.githubusercontent.com/17972674/213400423-de9e9c16-98f1-4bb6-aa4c-df07fdcfc8b5.png)|
